### PR TITLE
演習１でも main 関数が未定義に関するヒントを表示するように

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
@@ -43,6 +43,9 @@ exercises = Vector.fromList [exercise1, exercise2, exercise3, exercise4]
       | "parse error on input" `Text.isInfixOf` msg
           && "'" `Text.isInfixOf` code =
             "HINT: In Haskell, you must surround string literals with double-quote '\"'. Such as \"Hello, world\"."
+      | ("parse error" `Text.isInfixOf` msg || "Parse error" `Text.isInfixOf` msg)
+          && "top-level declaration expected." `Text.isInfixOf` msg =
+            "HINT: This error indicates you haven't defined main function."
       | "Variable not in scope: main :: IO" `Text.isInfixOf` msg =
         "HINT: This error indicates you haven't defined main function."
       | "Variable not in scope:" `Text.isInfixOf` msg =
@@ -93,6 +96,9 @@ exercises = Vector.fromList [exercise1, exercise2, exercise3, exercise4]
       | "parse error on input" `Text.isInfixOf` msg
           && "'" `Text.isInfixOf` code =
             "HINT: In Haskell, you must surround string literals with double-quote '\"'. Such as \"Hello, world\"."
+      | ("parse error" `Text.isInfixOf` msg || "Parse error" `Text.isInfixOf` msg)
+          && "top-level declaration expected." `Text.isInfixOf` msg =
+            "HINT: This error indicates you haven't defined main function."
       | "Variable not in scope: main :: IO" `Text.isInfixOf` msg =
         "HINT: This error indicates you haven't defined main function."
       | "Variable not in scope:" `Text.isInfixOf` msg =

--- a/test/Education/MakeMistakesToLearnHaskell/Exercise1Spec.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/Exercise1Spec.hs
@@ -25,4 +25,10 @@ spec = do
     "1"
     "single-quote"
     ["HINT: In Haskell, you must surround string literals with double-quote '\"'. Such as \"Hello, world\"."]
+
+  itShouldFailForCaseWithMessage
+    "1"
+    "no-main"
+    ["HINT: This error indicates you haven't defined main function."]
+
   itShouldFailForCaseWithMessage "1" "typo" []

--- a/test/Education/MakeMistakesToLearnHaskell/Exercise3Spec.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/Exercise3Spec.hs
@@ -31,6 +31,11 @@ spec = do
 
   itShouldFailForCaseWithMessage
     "3"
+    "no-main"
+    ["HINT: This error indicates you haven't defined main function."]
+
+  itShouldFailForCaseWithMessage
+    "3"
     "incornsistent-indent1"
     ["HINT: instructions in a `do` must be in a consistent width."]
 

--- a/test/assets/1/error-messages/no-main.txt
+++ b/test/assets/1/error-messages/no-main.txt
@@ -1,0 +1,8 @@
+[1 of 1] Compiling Main             ( S:\s\makeMistakesToLearnHaskell\test\assets\1\no-main.hs, S:\s\makeMistakesToLearnHaskell\test\assets\1\no-main.o )
+
+S:\s\makeMistakesToLearnHaskell\test\assets\1\no-main.hs:1:1: error:
+    Parse error: module header, import declaration
+    or top-level declaration expected.
+  |
+1 | print "Hello, world!"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/assets/3/error-messages/no-main.txt
+++ b/test/assets/3/error-messages/no-main.txt
@@ -1,0 +1,8 @@
+[1 of 1] Compiling Main             ( S:\s\makeMistakesToLearnHaskell\test\assets\3\no-main.hs, S:\s\makeMistakesToLearnHaskell\test\assets\3\no-main.o )
+
+S:\s\makeMistakesToLearnHaskell\test\assets\3\no-main.hs:1:1: error:
+    Parse error: module header, import declaration
+    or top-level declaration expected.
+  |
+1 | putStrLn "#     # ####### #       #        #####"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/assets/3/no-main.hs
+++ b/test/assets/3/no-main.hs
@@ -1,0 +1,7 @@
+putStrLn "#     # ####### #       #        #####"
+putStrLn "#     # #       #       #       #     #"
+putStrLn "#     # #       #       #       #     #"
+putStrLn "####### #####   #       #       #     #"
+putStrLn "#     # #       #       #       #     #"
+putStrLn "#     # #       #       #       #     #"
+putStrLn "#     # ####### ####### #######  #####"


### PR DESCRIPTION
see: #8 

ついでに３も。
演習２で出てたのは

https://github.com/haskell-jp/makeMistakesToLearnHaskell/blob/8c581fd1ebe5872969b3980f25a9d48924b5c9c4/src/Education/MakeMistakesToLearnHaskell/Exercise.hs#L57-L60

にマッチしてたからですね。
なので同様の条件を演習１と３にも足しました。

(だいぶ愚直なので、全体的にヒント出すとこはリファクタリングしたいですね 😅 )