### PR TITLE
Complete exercise 4

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell/Evaluator/Regex.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Evaluator/Regex.hs
@@ -4,17 +4,62 @@
 --   useful for evaluating source code input by the user.
 
 module Education.MakeMistakesToLearnHaskell.Evaluator.Regex
-  ( matchSubstring
-  , matchesSubstring
+  ( GhcToken
+  , matchSub
+  , matchesSub
+  , dropUntilFirst
+
+  , singleArgFunApp
   ) where
 
 
 #include <imports/external.hs>
 
+import           Education.MakeMistakesToLearnHaskell.Evaluator.Types
 
-matchSubstring :: Regex.RE s a -> [s] -> Maybe a
-matchSubstring re = Regex.match (Regex.few Regex.anySym *> re)
+type GhcToken = (GHC.Token, TextS.Text)
 
 
-matchesSubstring :: Regex.RE s a -> [s] -> Bool
-matchesSubstring re = isJust . matchSubstring re
+matchSub :: Regex.RE s a -> [s] -> Maybe a
+matchSub re =
+  Regex.match (Regex.few Regex.anySym *> re <* Regex.few Regex.anySym)
+
+
+matchesSub :: Regex.RE s a -> [s] -> Bool
+matchesSub re = isJust . matchSub re
+
+
+dropUntilFirst :: Regex.RE s a -> [s] -> [s]
+dropUntilFirst re xs =
+  maybe xs (\(_before, _matched, after) -> after) $ Regex.findFirstInfix re xs
+
+
+-- NOTE: Depth seeems required due to the limitation of regex-applicative,
+--       which has to scan all regex before executing.
+singleArgFunApp :: Natural -> Regex.RE GhcToken SingleArgFunApp
+singleArgFunApp depth =
+  insideParens
+    $   SingleArgFunApp
+    <$> identifier
+    <*  skipSpace
+    <*> (if depth == 0 then pure Nothing else optional $ singleArgFunApp $ depth - 1)
+
+  where
+    symbol :: TextS.Text -> Regex.RE GhcToken ()
+    symbol t = void $ Regex.sym (GHC.SymbolTok, t)
+
+    hasSympol :: TextS.Text -> Regex.RE GhcToken Bool
+    hasSympol t = (symbol t $> True) <|> pure False
+
+    identifier :: Regex.RE GhcToken TextS.Text
+    identifier = snd <$> Regex.psym ((== GHC.VariableTok) . fst)
+
+    skipSpace :: Regex.RE GhcToken ()
+    skipSpace = void $ optional (Regex.psym ((== GHC.SpaceTok) . fst))
+
+    insideParens :: Regex.RE GhcToken (HasParens -> a) -> Regex.RE GhcToken a
+    insideParens re =
+      (symbol "(" *> skipSpace *> re <*> (toHasParens <$> (skipSpace *> hasSympol ")"))) <|> (re <*> pure NoParens)
+
+    toHasParens :: Bool -> HasParens
+    toHasParens = bool OnlyOpenParen BothParens

--- a/src/Education/MakeMistakesToLearnHaskell/Evaluator/Types.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Evaluator/Types.hs
@@ -4,6 +4,8 @@ module Education.MakeMistakesToLearnHaskell.Evaluator.Types
   ( ErrorCode
   , ErrorMessage
   , RunHaskellError(..)
+  , SingleArgFunApp(..)
+  , HasParens(..)
   ) where
 
 
@@ -18,3 +20,14 @@ data RunHaskellError =
   RunHaskellNotFound | RunHaskellFailure ErrorCode ErrorMessage deriving (Show, Typeable)
 
 instance Exception RunHaskellError
+
+data HasParens =
+  NoParens | OnlyOpenParen | BothParens
+  deriving (Eq, Show)
+
+
+data SingleArgFunApp = SingleArgFunApp
+  { singleArgFunAppFunName :: !TextS.Text
+  , singleArgFunAppArg :: !(Maybe SingleArgFunApp)
+  , singleArgFunAppHasParen :: !HasParens
+  } deriving (Eq, Show)

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/FormatMessage.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/FormatMessage.hs
@@ -1,0 +1,40 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Education.MakeMistakesToLearnHaskell.Exercise.FormatMessage
+  ( formatSingleArgFunApp
+  ) where
+
+
+#include <imports/external.hs>
+
+import           Education.MakeMistakesToLearnHaskell.Exercise.Types
+import           Education.MakeMistakesToLearnHaskell.Evaluator.Types
+
+
+formatSingleArgFunApp :: SingleArgFunApp -> [Details]
+formatSingleArgFunApp = List.unfoldr uf
+  where
+    uf safa1 =
+      let f safa2 =
+            let hint =
+                  case singleArgFunAppHasParen safa2 of
+                      BothParens    -> ""
+                      NoParens      ->
+                        "HINT: No parentheses between "
+                          <> singleArgFunAppFunName safa1
+                          <> " and "
+                          <> singleArgFunAppFunName safa2
+                          <> "."
+                      OnlyOpenParen ->
+                        "HINT: The open parenthesis between "
+                          <> singleArgFunAppFunName safa1
+                          <> " and "
+                          <> singleArgFunAppFunName safa2
+                          <> " is not closed."
+            in
+              -- NOTE: The final argument should not be tested because it should be a raw expression.
+              --       E.g. The `input` argument of `reverse (lines input)`.
+              if isJust $ singleArgFunAppArg safa2
+                then Just (Text.fromStrict hint, safa2)
+                else Nothing
+      in f =<< singleArgFunAppArg safa1

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -1,7 +1,7 @@
 -- Common import statements for external libraries.
 -- Intended to include by CPP.
 
-import           Control.Applicative ((<|>))
+import           Control.Applicative ((<|>), optional)
 import qualified Control.Error as Error
 import           Control.Exception
                    ( Exception
@@ -14,9 +14,11 @@ import           Control.Exception
 import           Control.Monad (zipWithM_, void)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Trans.Maybe as MaybeT
+import           Data.Bool (bool)
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as ByteString
 import qualified Data.Char as Char
+import           Data.Functor (($>))
 import qualified Data.List as List
 import           Data.Maybe (fromMaybe, maybeToList, isJust)
 import           Data.IORef
@@ -39,6 +41,7 @@ import qualified Data.Yaml.TH as Yaml
 import qualified Debug.Trace as Debug
 import           GHC.Generics (Generic)
 import qualified GHC.SyntaxHighlighter as GHC
+import           Numeric.Natural (Natural)
 import           Safe (readMay, headMay)
 import qualified System.Directory as Dir
 import qualified System.Environment as Env

--- a/test/Education/MakeMistakesToLearnHaskell/Exercise4Spec.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/Exercise4Spec.hs
@@ -66,44 +66,47 @@ spec = do
   itShouldFailForCaseWithMessage
     "4"
     "no-close-paren"
-    ["HINT: you might have forgot to write close parenthesis"]
+    ["HINT: The open parenthesis between putStr and unlines is not closed."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-main"
-    ["HINT: This error indicates you haven't defined main function."]
+    ["HINT: Your source code dosn't have `main` function!"]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-open-paren1"
-    ["HINT: Close! You might have forgot to write open parenthesis between `putStr` and `unlines`."]
+    ["HINT: No parentheses between putStr and unlines."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-open-paren2"
-    ["HINT: Close! You might have forgot to write open parenthesis between `unlines` and `reverse`."]
+    ["HINT: No parentheses between unlines and reverse."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-open-paren3"
-    ["HINT: Close! You might have forgot to write open parenthesis between `reverse` and `lines`."]
+    ["HINT: No parentheses between reverse and lines."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-paren"
-    ["HINT: Unfortunately, you have to surround each function calls with parentheses! E.g. (func1 (func2 input))"]
+    [ "HINT: No parentheses between putStr and unlines"
+    , "HINT: No parentheses between unlines and reverse."
+    , "HINT: No parentheses between reverse and lines."
+    ]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-paren1"
-    ["HINT: You might have forgot to surround `unlines` and its argument with parentheses."]
+    ["HINT: No parentheses between putStr and unlines."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-paren2"
-    ["HINT: You might have forgot to surround `reverse` and its argument with parentheses."]
+    ["HINT: No parentheses between unlines and reverse."]
 
   itShouldFailForCaseWithMessage
     "4"
     "no-paren3"
-    ["HINT: You might have forgot to surround `lines` and its argument with parentheses."]
+    ["HINT: No parentheses between reverse and lines."]


### PR DESCRIPTION
カッコの有無についてのヒント判定処理を実装しました。
ghc-syntax-highlighterやregex-applicativeを使って、従来より正確な（空白の有無などに左右されない）マッチをする際のサンプルとしてもどうぞ。

実際にやってみた感想としては、`[GhcToken]`を`newtype`してmegaparsecの`Stream`型クラスを実装した方が楽に実装できたんじゃないか、という気もします。 :sweat_smile:
ただ、改めて調べた感じ[Minimal complete definition](http://hackage.haskell.org/package/megaparsec-7.0.1/docs/Text-Megaparsec-Stream.html)が結構多いのでそれはそれで大変だったかも知れません。