### PR TITLE
Fix #7 課題2.5「計算アプリケーションを作る（概要）」をmmlh showで表示できるようにする

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,7 @@ library:
   - filepath
   - ghc-syntax-highlighter
   - hint
+  - insert-ordered-containers
   # - i18n Use in the future
   - NoTrace
   - QuickCheck

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -44,8 +44,8 @@ printExerciseList = do
   Text.putStrLn ""
   Text.putStrLn "## Contents"
 
-  let printHeader n h = Text.putStrLn $ Text.pack (show n) <> ". " <> h
-  zipWithM_ printHeader ([1..] :: [Int]) =<< Exercise.loadHeaders
+  let printHeader h = Text.putStrLn $ "- " <> h
+  mapM_ printHeader =<< Exercise.loadHeaders
 
   Text.putStrLn $ "\nRun `" <> Text.pack appName <> " show <the exercise number>` to try the exercise."
 
@@ -68,13 +68,15 @@ verifySource e (file : _) = do
       Exercise.Error details -> do
         Error.errLn $ Text.toStrict $ details <> "\n\n"
         die "An unexpected error occurred when evaluating your solution."
+      Exercise.NotVerified -> do
+        Text.putStrLn "[NOT VERIFIED] This exercise has no test. Go ahead!"
+        Exit.exitSuccess
 
 
 showExercise :: Env -> [String] -> IO ()
 showExercise _ [] = die "Specify an exercise number to show"
-showExercise e (nStr : _) = do
-  n <- dieWhenNothing ("Invalid exercise id: '" ++ nStr ++ "'") (readMay nStr)
-  d <- Exercise.loadDescriptionById n
-        >>= dieWhenNothing ("Exercise id " ++ nStr ++ " not found!")
-  Exercise.saveLastShownId e n
+showExercise e (n : _) = do
+  d <- Exercise.loadDescriptionByName n
+        >>= dieWhenNothing ("Exercise id " ++ n ++ " not found!")
+  Exercise.saveLastShownName e n
   Text.putStr d

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Record.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Record.hs
@@ -1,8 +1,8 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Education.MakeMistakesToLearnHaskell.Exercise.Record
-  ( loadLastShownId
-  , saveLastShownId
+  ( loadLastShownName
+  , saveLastShownName
   ) where
 
 #include <imports/external.hs>
@@ -12,19 +12,19 @@ import           Education.MakeMistakesToLearnHaskell.Exercise.Types
 import           Education.MakeMistakesToLearnHaskell.Error
 
 
-loadLastShownId :: Env -> IO ExerciseId
-loadLastShownId e = do
+loadLastShownName :: Env -> IO Name
+loadLastShownName e = do
   path <- prepareRecordFilePath e
   exists <- Dir.doesFileExist path
   if exists
     then
-      lastShownId <$> (throwWhenLeft =<< Yaml.decodeFileEither path)
+      lastShownName <$> (throwWhenLeft =<< Yaml.decodeFileEither path)
     else
-      return 1
+      return "1"
 
 
-saveLastShownId :: Env -> ExerciseId -> IO ()
-saveLastShownId e n = do
+saveLastShownName :: Env -> Name -> IO ()
+saveLastShownName e n = do
   path <- prepareRecordFilePath e
   Yaml.encodeFile path $ Record n
 

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
@@ -9,17 +9,26 @@ import           Education.MakeMistakesToLearnHaskell.Env
 
 data Exercise =
   Exercise
-    { exerciseName :: !String
+    { exerciseName :: !Name
+    -- ^ The name of the exercise.
     , verify :: Env -> String -> IO Result
+    -- ^ The function to verify the source file, project directory,
+    --   or any string pointing to the user's answer.
+    --   So, the second argument's @String@ is something
+    --   pointing to the user's answer.
     }
 
 
 data Result =
-  Error !Details | Fail !Details | Success !Details deriving (Eq, Show)
+    Error !Details
+  | Fail !Details
+  | Success !Details
+  | NotVerified
+  deriving (Eq, Show)
 
 newtype Record =
   Record
-    { lastShownId :: ExerciseId
+    { lastShownName :: Name
     } deriving Generic
 
 instance Yaml.FromJSON Record
@@ -29,8 +38,6 @@ type Details = Text
 
 type SourceCode = Text
 
-type ExerciseId = Int
-
-type Name = String -- TODO: Replace ExerciseId
+type Name = String
 
 type Diagnosis = SourceCode -> Details -> Details

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -11,7 +11,7 @@ import           Control.Exception
                    , throwIO
                    , throw
                    )
-import           Control.Monad (zipWithM_, void)
+import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Trans.Maybe as MaybeT
 import           Data.Bool (bool)
@@ -19,6 +19,8 @@ import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as ByteString
 import qualified Data.Char as Char
 import           Data.Functor (($>))
+import           Data.HashMap.Strict.InsOrd (InsOrdHashMap)
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import qualified Data.List as List
 import           Data.Maybe (fromMaybe, maybeToList, isJust)
 import           Data.IORef
@@ -34,15 +36,13 @@ import qualified Data.Text.Lazy.IO as Text
 import qualified Data.Text.Lazy.Encoding as TextEncoding
 import qualified Data.Text as TextS
 import           Data.Typeable (Typeable)
-import           Data.Vector (Vector, (!?), (!))
-import qualified Data.Vector as Vector
 import qualified Data.Yaml as Yaml
 import qualified Data.Yaml.TH as Yaml
 import qualified Debug.Trace as Debug
 import           GHC.Generics (Generic)
 import qualified GHC.SyntaxHighlighter as GHC
 import           Numeric.Natural (Natural)
-import           Safe (readMay, headMay)
+import           Safe (headMay)
 import qualified System.Directory as Dir
 import qualified System.Environment as Env
 import qualified System.Exit as Exit

--- a/test/Education/MakeMistakesToLearnHaskell/Exercise2Spec.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/Exercise2Spec.hs
@@ -22,7 +22,7 @@ main = hspec spec
 spec :: Spec
 spec = do
   baseEnv <- mkDefaultSpecEnv
-  let subject = Exercise.unsafeGetById 2
+  let subject = Exercise.unsafeGetByName "2"
 
   it "given the correct answer, show SUCCESS" $ do
     out <- ByteString.readFile "test/assets/2/error-messages/correct.txt"

--- a/test/Education/MakeMistakesToLearnHaskell/Exercise3Spec.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/Exercise3Spec.hs
@@ -22,7 +22,7 @@ main = hspec spec
 spec :: Spec
 spec = do
   baseEnv <- mkDefaultSpecEnv
-  let subject = Exercise.unsafeGetById 3
+  let subject = Exercise.unsafeGetByName "3"
 
   it "given the correct answer, show SUCCESS" $ do
     out <- ByteString.readFile "test/assets/3/error-messages/correct.txt"

--- a/test/Education/MakeMistakesToLearnHaskell/SpecHelper.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/SpecHelper.hs
@@ -12,12 +12,14 @@ shouldFail :: Exercise.Result -> IO Exercise.Details
 shouldFail (Exercise.Fail d) = return d
 shouldFail (Exercise.Success d) = fail $ "Unexpected Success: " ++ show d
 shouldFail (Exercise.Error d) = fail $ "Unexpected Error: " ++ show d
+shouldFail Exercise.NotVerified = fail "Unexpected Not verified."
 
 
 shouldSuccess :: Exercise.Result -> IO Exercise.Details
 shouldSuccess (Exercise.Fail d) = fail $ "Unexpected Fail: " ++ show d
 shouldSuccess (Exercise.Success d) = return d
 shouldSuccess (Exercise.Error d) = fail $ "Unexpected Error: " ++ show d
+shouldSuccess Exercise.NotVerified = fail "Unexpected Not verified."
 
 
 type TestCaseId = String
@@ -26,7 +28,7 @@ itShouldFailForCaseWithMessage :: Exercise.Name -> TestCaseId -> [Exercise.Detai
 itShouldFailForCaseWithMessage ename tcid messages = do
   baseEnv <- mkDefaultSpecEnv
   it (ename ++ "::" ++ tcid) $ do
-    let subject = Exercise.unsafeGetById (read ename)
+    let subject = Exercise.unsafeGetByName ename
     err <- ByteString.readFile $ "test/assets/" ++ ename ++ "/error-messages/" ++ tcid ++ ".txt"
     let e = setRunHaskellFailureWithOutput baseEnv err
     d <- shouldFail =<< Exercise.verify subject e ("test/assets/" ++ ename ++ "/" ++ tcid ++ ".hs")

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -27,6 +27,10 @@ spec =
       runMmlh ["verify", "test/assets/common/empty.hs"]
         >>= shouldExitWithHints ["HINT: This error indicates you haven't defined main function."]
 
+    it "given non-existing answer of exercise 2.5, show NOT VERIFIED" $ do
+      void $ runMmlh ["show", "2.5"]
+      runMmlh ["verify", "non-existing"] >>= shouldPrintNotVerified
+
     it "given the correct answer of exercise 4, show SUCCESS" $ do
       answerFile <- Paths_makeMistakesToLearnHaskell.getDataFileName ("assets" </> "4.hs")
       void $ runMmlh ["show", "4"]
@@ -71,4 +75,12 @@ shouldVerifySuccess (ProcessResult out err code ex) = do
   fmap show ex `shouldBe` Nothing
   err `shouldSatisfy` ByteString'.null
   out `shouldSatisfy` includes "SUCCESS"
+  code `shouldBe` ExitSuccess
+
+
+shouldPrintNotVerified :: ProcessResult -> IO ()
+shouldPrintNotVerified (ProcessResult out err code ex) = do
+  fmap show ex `shouldBe` Nothing
+  err `shouldSatisfy` ByteString'.null
+  out `shouldSatisfy` includes "NOT VERIFIED"
   code `shouldBe` ExitSuccess


### PR DESCRIPTION
- 対応方法としては、「`ExcerciseId` として `Int` ではなく文字列を使用できるようにする（いずれにしてもおいおいやりたい）」を採用し、隅から隅まで直しました。
- ユーザーが解く必要がない課題に対応するために、`NotVerified`という値コンストラクターを`Result`に追加しました。  
  課題2.5のようなケースは今後も出てくると思うので適宜使います（純粋にまだ問題の判定処理を実装できてない場合とか）。