### PR TITLE
read UTF-8 files as UTF-8

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
@@ -225,7 +225,7 @@ runHaskellExercise diag right e prgFile = do
               return $ Error "runhaskell command is not available.\nInstall stack or Haskell Platform."
             RunHaskell.RunHaskellFailure _ msg -> do
               logDebug e $ "RunHaskellFailure: " <> msg
-              code <- Text.readFile prgFile
+              code <- readUtf8File prgFile
               return $ Fail $ appendDiagnosis diag code msg
 
 
@@ -239,7 +239,7 @@ runHaskellExerciseWithStdin diag calcRight e prgFile = do
             { runHaskellParametersArgs = [prgFile]
             , runHaskellParametersStdin = TextEncoding.encodeUtf8 input
             }
-      code <- Text.readFile prgFile
+      code <- readUtf8File prgFile
       result <- resultForUser diag code ["            For input: " <> Text.pack (show input)] calcRight input <$> runHaskell e params
       writeIORef resultRef result
       return $
@@ -301,7 +301,7 @@ loadExampleSolution = loadWithExtension ".hs"
 loadWithExtension :: String -> Exercise -> IO Text
 loadWithExtension ext ex =
   Paths_makeMistakesToLearnHaskell.getDataFileName ("assets/" ++ exerciseName ex ++ ext)
-    >>= Text.readFile
+    >>= readUtf8File
 
 
 loadDescriptionByName :: Name -> IO (Maybe Text)

--- a/src/Education/MakeMistakesToLearnHaskell/Text.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Text.hs
@@ -3,6 +3,7 @@
 module Education.MakeMistakesToLearnHaskell.Text
   ( canonicalizeNewlines
   , decodeUtf8
+  , readUtf8File
   ) where
 
 
@@ -19,3 +20,10 @@ decodeUtf8 = TextEncoding.decodeUtf8With handler
     handler _ (Just _) = Just ' '
     handler cause nothing =
       throw $ TextEncoding.DecodeError cause nothing
+
+
+readUtf8File :: FilePath -> IO Text
+readUtf8File path = do
+  hd <- IO.openFile path IO.ReadMode
+  IO.hSetEncoding hd IO.utf8
+  Text.hGetContents hd


### PR DESCRIPTION
On some environments such as Japanese Windows,
`Text.readFile` tries to read a file encoded as non-UTF-8 (e.g. CP932).
This causes an error due to the incompatible encodings.

And in mmlh, all text files are encoded as UTF-8.
So decided to read the files always as UTF-8.