### PR TITLE
Windows のための CI を追加

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,11 @@
 
 build: off
 
+init:
+- ps: Set-WinSystemLocale ja-JP
+- ps: Start-Sleep -s 5
+- ps: Restart-Computer
+
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
-- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
+- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-x86_64.zip
 - 7z x stack.zip stack.exe
 
 clone_folder: "c:\\stack"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
     TMP: "c:\\tmp"
 
 test_script:
+- chcp 932
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+# Disabled cache in hope of improving reliability of AppVeyor builds
+#cache:
+#- "c:\\sr" # stack root, short paths == fewer problems
+
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+    TMP: "c:\\tmp"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test --jobs 1


### PR DESCRIPTION
AppVeyor を使うと OSS は無料で Windows OS のビルドを CI できるらしい。
https://www.appveyor.com/pricing/

設定ファイルは stack から引っ張ってきた。
https://github.com/commercialhaskell/stack/blob/master/appveyor.yml

