### PR TITLE
insert-ordered-containers から containers に切り替え

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -41,12 +41,12 @@ library:
   # TODO: Decide version
   - QuickCheck
   - bytestring
+  - containers
   - directory
   - errors
   - filepath
   - ghc-syntax-highlighter
   - hint
-  - insert-ordered-containers
   # - i18n Use in the future
   - QuickCheck
   - regex-applicative

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
@@ -30,9 +30,9 @@ import           Education.MakeMistakesToLearnHaskell.Error
 import           Education.MakeMistakesToLearnHaskell.Text
 
 
-exercises :: InsOrdHashMap Name Exercise
+exercises :: Map Name Exercise
 exercises =
-  InsOrdHashMap.fromList
+  Map.fromList
     $ map (\e -> (exerciseName e, e)) [exercise1, exercise2, exercise2_5, exercise3, exercise4, exercise5]
   where
     exercise1 =
@@ -278,7 +278,7 @@ notYetImplementedVeirificationExercise _ _ = return NotYetImplemented
 
 
 loadHeaders :: IO [Text]
-loadHeaders = mapM loadHeader $ InsOrdHashMap.elems exercises
+loadHeaders = mapM loadHeader $ Map.elems exercises
   where
     loadHeader ex = extractHeader ex =<< loadDescription ex
 
@@ -322,7 +322,7 @@ loadLastShown e =
 
 
 getByName :: Name -> Maybe Exercise
-getByName n = InsOrdHashMap.lookup n exercises
+getByName n = Map.lookup n exercises
 
 
 unsafeGetByName :: Name -> Exercise

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -19,9 +19,9 @@ import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as ByteString
 import qualified Data.Char as Char
 import           Data.Functor (($>))
-import           Data.HashMap.Strict.InsOrd (InsOrdHashMap)
-import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import qualified Data.List as List
+import           Data.Map (Map)
+import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, maybeToList, isJust)
 import           Data.IORef
                    ( newIORef


### PR DESCRIPTION
#37

- `insert-ordered-containers` の依存関係を削除し、代わりに `containers` パッケージを利用するように変更
- `InsOrdHashMap` 型の代わりに lazy `Map` を利用

```shell
# 切り替え前
$ stack ls dependencies | wc -l
85

# 切り替え後
$ stack ls dependencies | wc -l
65
```