### PR TITLE
T9 cmark

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ library:
   # TODO: Decide version
   - QuickCheck
   - bytestring
+  - cmark
   - directory
   - errors
   - filepath

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ library:
   - ghc-syntax-highlighter
   - hint
   # - i18n Use in the future
+  - open-browser
   - QuickCheck
   - regex-applicative
   - safe

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -84,4 +84,12 @@ showExercise e (n : _) = do
   d <- Exercise.loadDescriptionByName n
         >>= dieWhenNothing ("Exercise id " ++ n ++ " not found!")
   Exercise.saveLastShownName e n
-  Text.putStr d
+  showMarkdown d n
+
+showMarkdown :: Text -> String -> IO ()
+showMarkdown md n = do
+  let htmlContent = CMark.commonmarkToHtml [CMark.optSafe] $ Text.toStrict md
+      mkHtmlPath dir = dir <> "/" <> "mmlh-ex" <> n <> ".html"
+  path <- mkHtmlPath <$> Dir.getTemporaryDirectory
+
+  TextS.writeFile path htmlContent

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -99,4 +99,5 @@ showMarkdown md n = do
   if isSuccess then
     return ()
   else
-    error "error: openBrowser is Failure."
+    -- ブラウザの起動に失敗した場合はコンソールに出力する
+    Text.putStr md

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -93,3 +93,10 @@ showMarkdown md n = do
   path <- mkHtmlPath <$> Dir.getTemporaryDirectory
 
   TextS.writeFile path htmlContent
+
+  isSuccess <- Browser.openBrowser path
+
+  if isSuccess then
+    return ()
+  else
+    error "error: openBrowser is Failure."

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -54,6 +54,7 @@ import qualified System.Process.Typed as Process
 import qualified Test.QuickCheck as QuickCheck
 import           Test.QuickCheck (quickCheckWithResult)
 import qualified Text.Regex.Applicative as Regex
+import qualified Web.Browser as Browser
 #ifdef mingw32_HOST_OS
 import qualified System.Win32.Console as Win32
 import GHC.IO.Encoding.CodePage (mkLocaleEncoding)

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -1,6 +1,7 @@
 -- Common import statements for external libraries.
 -- Intended to include by CPP.
 
+import qualified CMark
 import           Control.Applicative ((<|>), optional)
 import qualified Control.Error as Error
 import           Control.Exception
@@ -33,6 +34,7 @@ import qualified Data.Text.Lazy as Text
 import qualified Data.Text.Lazy.IO as Text
 import qualified Data.Text.Lazy.Encoding as TextEncoding
 import qualified Data.Text as TextS
+import qualified Data.Text.IO as TextS
 import           Data.Typeable (Typeable)
 import qualified Data.Yaml as Yaml
 import qualified Data.Yaml.TH as Yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,7 @@ packages:
 extra-deps:
 - main-tester-0.2.0.0
 - NoTrace-0.3.0.3
+- cmark-0.5.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
#9

- markdown コンテンツを [cmark](https://www.stackage.org/package/cmark) パッケージを利用して html コンテンツに変換 (その際、Lazy Text から Strict Text に変換する必要があります)
- html コンテンツをファイルに保存
  - 保存先のディレクトリは [getTemporaryDirectory](https://www.stackage.org/haddock/lts-12.16/directory-1.3.1.5/System-Directory.html#v:getTemporaryDirectory) で取得した tmp ディクレトリを指定
  - ファイル名はとりあえず `mmlh-exN.html` という形式にしました。(`N` は markdown ファイルのファイル名)
- [open-browser](https://www.stackage.org/lts-12.16/package/open-browser-0.2.1.0) パッケージを使って保存したファイルをブラウザで開きます

また、`libcmark` はライブラリに付属しているそうなので、別途インストールする必要は無さそうです。

> This package provides Haskell bindings for libcmark, the reference parser for CommonMark, a fully specified variant of Markdown. It includes sources for libcmark and does not require prior installation of the C library.

cmark と open-browser ともに使ったことが無いので、おかしかったらご指摘ください。

また、cmark のオプションは [optSafe](https://www.stackage.org/haddock/lts-11.22/cmark-0.5.6/CMark.html#v:optSafe) を指定しましたが、必要無いかもしれません。ご確認ください。