### PR TITLE
テストケースの進捗を可視化

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
@@ -236,7 +236,7 @@ runHaskellExercise diag right e prgFile = do
 runHaskellExerciseWithStdin :: Diagnosis -> (Text -> Text) -> Env -> FilePath -> IO Result
 runHaskellExerciseWithStdin diag calcRight e prgFile = do
   resultRef <- newIORef $ error "Assertion failure: no result written after QuickCheck"
-  qr <- quickCheckWithResult QuickCheck.stdArgs { QuickCheck.chatty = False } $ \ls ->
+  qr <- quickCheckWithResult QuickCheck.stdArgs { QuickCheck.chatty = True } $ \ls ->
     QuickCheck.ioProperty $ do
       let input = Text.pack $ unlines ls
           params = defaultRunHaskellParameters


### PR DESCRIPTION
`stack run verify assets/4.hs` コマンド実行後、
少しの間何も起きないため動作してるのかどうか不安になります。

```shell
$  time stack run mmlh verify assets/4.hs
real    0m31.616s
user    0m24.498s
sys     0m7.566s
```

修正後はテストケースの進捗を表示するようにしました。

```shell
> stack run verify assets/4.hs
checking
checking.
checking..
checking...
checking....
checking.....
checking......
checking.......
checking........
checking.........
```

のようにテストケースを1つ処理すると `.` が1つ増えます。