### PR TITLE
hlint, vector, yaml の依存関係削除

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,6 @@ library:
   - errors
   - filepath
   - ghc-syntax-highlighter
-  - hint
   # - i18n Use in the future
   - open-browser
   - QuickCheck
@@ -55,8 +54,6 @@ library:
   - text
   - transformers
   - typed-process
-  - vector
-  - yaml
   when:
   - condition: os(windows)
     dependencies:

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Record.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Record.hs
@@ -16,17 +16,16 @@ loadLastShownName :: Env -> IO Name
 loadLastShownName e = do
   path <- prepareRecordFilePath e
   exists <- Dir.doesFileExist path
-  if exists
-    then
-      lastShownName <$> (throwWhenLeft =<< Yaml.decodeFileEither path)
-    else
-      return "1"
+  if exists then
+    fmap (lastShownName . read) $ readFile path
+  else
+    return "1"
 
 
 saveLastShownName :: Env -> Name -> IO ()
 saveLastShownName e n = do
   path <- prepareRecordFilePath e
-  Yaml.encodeFile path $ Record n
+  writeFile path $ show $ Record n
 
 
 prepareRecordFilePath :: Env -> IO FilePath

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
@@ -27,13 +27,9 @@ data Result =
   | NotYetImplemented
   deriving (Eq, Show)
 
-newtype Record =
-  Record
-    { lastShownName :: Name
-    } deriving Generic
-
-instance Yaml.FromJSON Record
-instance Yaml.ToJSON Record
+newtype Record = Record
+  { lastShownName :: Name
+  } deriving (Show, Read)
 
 type Details = Text
 

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -36,8 +36,6 @@ import qualified Data.Text.Lazy.Encoding as TextEncoding
 import qualified Data.Text as TextS
 import qualified Data.Text.IO as TextS
 import           Data.Typeable (Typeable)
-import qualified Data.Yaml as Yaml
-import qualified Data.Yaml.TH as Yaml
 import qualified Debug.Trace as Debug
 import           GHC.Generics (Generic)
 import qualified GHC.SyntaxHighlighter as GHC


### PR DESCRIPTION
#46

- `hlint`, `vector`, `yaml` の依存関係削除
- `yaml` でやりとりしていた部分は `Read` と `Show` を利用するように変更