### PR TITLE
verify コマンドの e2e テストにおいて、出力先を常に Terminal となるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,7 @@ stack install
 - 他のHaskell入門書を読んでみたが、Haskellでプログラムを書く方法がわからない。
     - TODO: にしては今の内容はちょっと初歩的すぎるかもしれないので、このターゲット自体かexerciseの内容を改めよう
 - Haskellがどんな言語か、どうやってプログラムを作るのか、軽く知りたい。
+
+## 依存ライブラリ
+
+- [main-tester](https://gitlab.com/igrep/main-tester)

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -98,9 +98,8 @@ showMarkdown env md n = do
   isSuccess <-
     if isBrowser (envVerifyOutputLocation env) then
       Browser.openBrowser path
-    else do
-      Text.putStr md
-      return True
+    else
+      return False
 
   if isSuccess then
     return ()

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -28,13 +28,13 @@ withMainEnv :: (Env -> IO r) -> IO r
 withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
-  loc <- maybe Browser read <$> Env.lookupEnv markdownOutputEnvVarName
+  loc <- maybe Browser read <$> Env.lookupEnv showExerciseOutputEnvVarName
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
     let e = defaultEnv
               { logDebug = ByteString.hPutStr h . (<> "\n")
               , appHomePath = d
               , runHaskell = RunHaskell.runFile e
-              , envVerifyOutputLocation = loc
+              , envShowExerciseOutputLocation = loc
               }
     action e
 
@@ -96,7 +96,7 @@ showMarkdown env md n = do
   TextS.writeFile path htmlContent
 
   isSuccess <-
-    if envVerifyOutputLocation env == Browser then
+    if envShowExerciseOutputLocation env == Browser then
       Browser.openBrowser path
     else
       return False

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -28,13 +28,14 @@ withMainEnv :: (Env -> IO r) -> IO r
 withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
+  loc <- Env.getEnv terminalOutputEnvVarName
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
     let e = defaultEnv
-            { logDebug = ByteString.hPutStr h . (<> "\n")
-            , appHomePath = d
-            , runHaskell = RunHaskell.runFile e
-            , envQcMaxSuccessSize = 20
-            }
+              { logDebug = ByteString.hPutStr h . (<> "\n")
+              , appHomePath = d
+              , runHaskell = RunHaskell.runFile e
+              , envVerifyOutputLocation = read loc
+              }
     action e
 
 

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -29,8 +29,7 @@ withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
-    let e =
-          Env
+    let e = defaultEnv
             { logDebug = ByteString.hPutStr h . (<> "\n")
             , appHomePath = d
             , runHaskell = RunHaskell.runFile e

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -28,13 +28,13 @@ withMainEnv :: (Env -> IO r) -> IO r
 withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
-  loc <- Env.getEnv terminalOutputEnvVarName
+  loc <- maybe Browser read <$> Env.lookupEnv terminalOutputEnvVarName
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
     let e = defaultEnv
               { logDebug = ByteString.hPutStr h . (<> "\n")
               , appHomePath = d
               , runHaskell = RunHaskell.runFile e
-              , envVerifyOutputLocation = read loc
+              , envVerifyOutputLocation = loc
               }
     action e
 

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -96,7 +96,7 @@ showMarkdown env md n = do
   TextS.writeFile path htmlContent
 
   isSuccess <-
-    if isBrowser (envVerifyOutputLocation env) then
+    if envVerifyOutputLocation env == Browser then
       Browser.openBrowser path
     else
       return False

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -28,7 +28,7 @@ withMainEnv :: (Env -> IO r) -> IO r
 withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
-  loc <- maybe Browser read <$> Env.lookupEnv terminalOutputEnvVarName
+  loc <- maybe Browser read <$> Env.lookupEnv markdownOutputEnvVarName
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
     let e = defaultEnv
               { logDebug = ByteString.hPutStr h . (<> "\n")

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -3,12 +3,12 @@
 module Education.MakeMistakesToLearnHaskell.Env
   ( Env (..)
   , defaultEnv
-  , VerifyCmdOutputLocation (..)
+  , ShowExerciseOutputLocation (..)
   , RunHaskellParameters(runHaskellParametersArgs, runHaskellParametersStdin)
   , defaultRunHaskellParameters
   , appName
   , homePathEnvVarName
-  , markdownOutputEnvVarName
+  , showExerciseOutputEnvVarName
   , avoidCodingError
   )
 where
@@ -30,10 +30,10 @@ data Env = Env
   , appHomePath :: FilePath
   , runHaskell :: RunHaskellParameters -> IO (Either RunHaskellError (ByteString, ByteString))
   , envQcMaxSuccessSize :: Int
-  , envVerifyOutputLocation :: VerifyCmdOutputLocation -- ^ verify コマンドの出力先
+  , envShowExerciseOutputLocation :: ShowExerciseOutputLocation -- ^ mmlh show コマンドの出力先
   }
 
-data VerifyCmdOutputLocation
+data ShowExerciseOutputLocation
   = Browser
   | Terminal
   deriving (Eq, Show, Read)
@@ -44,7 +44,7 @@ defaultEnv = Env
   , appHomePath = error "Set appHomePath to defaultEnv"
   , runHaskell = error "Set runHaskell to defaultEnv"
   , envQcMaxSuccessSize = 20
-  , envVerifyOutputLocation = Browser
+  , envShowExerciseOutputLocation = Browser
   }
 
 appName :: String
@@ -54,8 +54,8 @@ appName = "mmlh"
 homePathEnvVarName :: String
 homePathEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_HOME"
 
-markdownOutputEnvVarName :: String
-markdownOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_MARKDOWN_OUTPUT_LOCATION"
+showExerciseOutputEnvVarName :: String
+showExerciseOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_SHOW_EXERCISE_OUTPUT_LOCATION"
 
 
 avoidCodingError :: IO ()

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -4,7 +4,6 @@ module Education.MakeMistakesToLearnHaskell.Env
   ( Env (..)
   , defaultEnv
   , VerifyCmdOutputLocation (..)
-  , isBrowser
   , RunHaskellParameters(runHaskellParametersArgs, runHaskellParametersStdin)
   , defaultRunHaskellParameters
   , appName
@@ -38,10 +37,6 @@ data VerifyCmdOutputLocation
   = Browser
   | Terminal
   deriving (Eq, Show, Read)
-
-isBrowser :: VerifyCmdOutputLocation -> Bool
-isBrowser Browser = True
-isBrowser _ = False
 
 defaultEnv :: Env
 defaultEnv = Env

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -2,6 +2,8 @@
 
 module Education.MakeMistakesToLearnHaskell.Env
   ( Env (..)
+  , VerifyCmdOutputLocation (..)
+  , isBrowser
   , RunHaskellParameters(runHaskellParametersArgs, runHaskellParametersStdin)
   , defaultRunHaskellParameters
   , appName
@@ -19,6 +21,9 @@ data RunHaskellParameters = RunHaskellParameters
   , runHaskellParametersStdin :: !ByteString
   }
 
+defaultRunHaskellParameters :: RunHaskellParameters
+defaultRunHaskellParameters = RunHaskellParameters [] ""
+
 data Env =
   Env
     { logDebug :: ByteString -> IO ()
@@ -27,8 +32,14 @@ data Env =
     , envQcMaxSuccessSize :: Int
     }
 
-defaultRunHaskellParameters :: RunHaskellParameters
-defaultRunHaskellParameters = RunHaskellParameters [] ""
+data VerifyCmdOutputLocation
+  = Browser
+  | Terminal
+  deriving (Eq, Show, Read)
+
+isBrowser :: VerifyCmdOutputLocation -> Bool
+isBrowser Browser = True
+isBrowser _ = False
 
 
 appName :: String

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -8,7 +8,7 @@ module Education.MakeMistakesToLearnHaskell.Env
   , defaultRunHaskellParameters
   , appName
   , homePathEnvVarName
-  , terminalOutputEnvVarName
+  , markdownOutputEnvVarName
   , avoidCodingError
   )
 where
@@ -54,8 +54,8 @@ appName = "mmlh"
 homePathEnvVarName :: String
 homePathEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_HOME"
 
-terminalOutputEnvVarName :: String
-terminalOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_TERMINAL_OUTPUT_LOCATION"
+markdownOutputEnvVarName :: String
+markdownOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_MARKDOWN_OUTPUT_LOCATION"
 
 
 avoidCodingError :: IO ()

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -9,6 +9,7 @@ module Education.MakeMistakesToLearnHaskell.Env
   , defaultRunHaskellParameters
   , appName
   , homePathEnvVarName
+  , terminalOutputEnvVarName
   , avoidCodingError
   )
 where
@@ -26,12 +27,12 @@ defaultRunHaskellParameters :: RunHaskellParameters
 defaultRunHaskellParameters = RunHaskellParameters [] ""
 
 data Env = Env
-    { logDebug :: ByteString -> IO ()
-    , appHomePath :: FilePath
-    , runHaskell :: RunHaskellParameters -> IO (Either RunHaskellError (ByteString, ByteString))
-    , envQcMaxSuccessSize :: Int
+  { logDebug :: ByteString -> IO ()
+  , appHomePath :: FilePath
+  , runHaskell :: RunHaskellParameters -> IO (Either RunHaskellError (ByteString, ByteString))
+  , envQcMaxSuccessSize :: Int
   , envVerifyOutputLocation :: VerifyCmdOutputLocation -- ^ verify コマンドの出力先
-    }
+  }
 
 data VerifyCmdOutputLocation
   = Browser
@@ -57,6 +58,9 @@ appName = "mmlh"
 
 homePathEnvVarName :: String
 homePathEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_HOME"
+
+terminalOutputEnvVarName :: String
+terminalOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_TERMINAL_OUTPUT_LOCATION"
 
 
 avoidCodingError :: IO ()

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -24,12 +24,12 @@ data RunHaskellParameters = RunHaskellParameters
 defaultRunHaskellParameters :: RunHaskellParameters
 defaultRunHaskellParameters = RunHaskellParameters [] ""
 
-data Env =
-  Env
+data Env = Env
     { logDebug :: ByteString -> IO ()
     , appHomePath :: FilePath
     , runHaskell :: RunHaskellParameters -> IO (Either RunHaskellError (ByteString, ByteString))
     , envQcMaxSuccessSize :: Int
+  , envVerifyOutputLocation :: VerifyCmdOutputLocation -- ^ verify コマンドの出力先
     }
 
 data VerifyCmdOutputLocation

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -2,6 +2,7 @@
 
 module Education.MakeMistakesToLearnHaskell.Env
   ( Env (..)
+  , defaultEnv
   , VerifyCmdOutputLocation (..)
   , isBrowser
   , RunHaskellParameters(runHaskellParametersArgs, runHaskellParametersStdin)
@@ -41,6 +42,14 @@ isBrowser :: VerifyCmdOutputLocation -> Bool
 isBrowser Browser = True
 isBrowser _ = False
 
+defaultEnv :: Env
+defaultEnv = Env
+  { logDebug = error "Set logDebug to defaultEnv"
+  , appHomePath = error "Set appHomePath to defaultEnv"
+  , runHaskell = error "Set runHaskell to defaultEnv"
+  , envQcMaxSuccessSize = 20
+  , envVerifyOutputLocation = Browser
+  }
 
 appName :: String
 appName = "mmlh"

--- a/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
@@ -13,12 +13,11 @@ mkDefaultSpecEnv :: SpecM a Env
 mkDefaultSpecEnv = runIO $ do
   tmpDir <- (</> "tmp/mmlh") <$> Dir.getCurrentDirectory
   return $ defaultEnv
-    { logDebug = const $ return ()
-    -- { logDebug = ByteString.putStrLn
-    , appHomePath = tmpDir
-    , runHaskell = error "Set runHaskell to defaultTestEnv!"
-    , envQcMaxSuccessSize = 20
-    }
+            { logDebug = const $ return ()
+            -- { logDebug = ByteString.putStrLn
+            , appHomePath = tmpDir
+            , envVerifyOutputLocation = Terminal
+            }
 
 
 setRunHaskellFailureWithOutput :: Env -> ByteString -> Env

--- a/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
@@ -16,7 +16,7 @@ mkDefaultSpecEnv = runIO $ do
             { logDebug = const $ return ()
             -- { logDebug = ByteString.putStrLn
             , appHomePath = tmpDir
-            , envVerifyOutputLocation = Terminal
+            , envShowExerciseOutputLocation = Terminal
             }
 
 

--- a/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
@@ -12,7 +12,7 @@ import           Education.MakeMistakesToLearnHaskell.Evaluator.Types
 mkDefaultSpecEnv :: SpecM a Env
 mkDefaultSpecEnv = runIO $ do
   tmpDir <- (</> "tmp/mmlh") <$> Dir.getCurrentDirectory
-  return Env
+  return $ defaultEnv
     { logDebug = const $ return ()
     -- { logDebug = ByteString.putStrLn
     , appHomePath = tmpDir

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -54,7 +54,7 @@ runMmlh :: [String] -> IO ProcessResult
 runMmlh args = do
   Dir.createDirectoryIfMissing False "./tmp/"
   let env = [ (homePathEnvVarName, Just "./tmp/")
-            , (markdownOutputEnvVarName, Just (show Terminal))
+            , (showExerciseOutputEnvVarName, Just (show Terminal))
             ]
   withArgs args
     $ withEnv env

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -54,7 +54,7 @@ runMmlh :: [String] -> IO ProcessResult
 runMmlh args = do
   Dir.createDirectoryIfMissing False "./tmp/"
   let env = [ (homePathEnvVarName, Just "./tmp/")
-            , (terminalOutputEnvVarName, Just (show Terminal))
+            , (markdownOutputEnvVarName, Just (show Terminal))
             ]
   withArgs args
     $ withEnv env

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -5,7 +5,7 @@ module Education.MakeMistakesToLearnHaskellSpec (main, spec) where
 #include <test/imports/external.hs>
 
 import qualified Education.MakeMistakesToLearnHaskell
-import           Education.MakeMistakesToLearnHaskell.Env (homePathEnvVarName)
+import           Education.MakeMistakesToLearnHaskell.Env
 
 
 -- `main` is here so that this module can be run from GHCi on its own.  It is
@@ -53,8 +53,11 @@ spec =
 runMmlh :: [String] -> IO ProcessResult
 runMmlh args = do
   Dir.createDirectoryIfMissing False "./tmp/"
+  let env = [ (homePathEnvVarName, Just "./tmp/")
+            , (terminalOutputEnvVarName, Just (show Terminal))
+            ]
   withArgs args
-    $ withEnv [(homePathEnvVarName, Just "./tmp/")]
+    $ withEnv env
     $ captureProcessResult Education.MakeMistakesToLearnHaskell.main
 
 


### PR DESCRIPTION
#49

## やったこと

- defaultEnv を追加し、それをベースに必要に応じて環境を設定するように変更
- Env に `envVerifyOutputLocation` フィールドを追加 (同様に適切な型と補助関数を追加)
- テスト時の verify コマンドは常に Terminal になるように修正
- `terminalOutputEnvVarName` 定数 (環境変数) を追加

Env のデフォルト値

```hs
defaultEnv :: Env
defaultEnv = Env
  { logDebug = error "Set logDebug to defaultEnv"
  , appHomePath = error "Set appHomePath to defaultEnv"
  , runHaskell = error "Set runHaskell to defaultEnv"
  , envQcMaxSuccessSize = 20
  , envVerifyOutputLocation = Browser
  }
```