### PR TITLE
コンソールにmarkdownを書き出す際に末尾の空白を全て削除するように変更

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -11,6 +11,7 @@ import           Education.MakeMistakesToLearnHaskell.Env
 import qualified Education.MakeMistakesToLearnHaskell.Exercise as Exercise
 import qualified Education.MakeMistakesToLearnHaskell.Evaluator.RunHaskell as RunHaskell
 import           Education.MakeMistakesToLearnHaskell.Error
+import           Education.MakeMistakesToLearnHaskell.Text
 
 
 main :: IO ()
@@ -105,4 +106,4 @@ showMarkdown env md n = do
     return ()
   else
     -- ブラウザの起動に失敗した場合はコンソールに出力する
-    Text.putStr md
+    Text.putStr $ removeAllTrailingSpace md

--- a/src/Education/MakeMistakesToLearnHaskell/Text.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Text.hs
@@ -4,6 +4,7 @@ module Education.MakeMistakesToLearnHaskell.Text
   ( canonicalizeNewlines
   , decodeUtf8
   , readUtf8File
+  , removeAllTrailingSpace
   ) where
 
 
@@ -27,3 +28,6 @@ readUtf8File path = do
   hd <- IO.openFile path IO.ReadMode
   IO.hSetEncoding hd IO.utf8
   Text.hGetContents hd
+
+removeAllTrailingSpace :: Text -> Text
+removeAllTrailingSpace = Text.unlines . map Text.stripEnd . Text.lines


### PR DESCRIPTION
#26

issue では末尾の空白2つということでしたが、[stripEnd](https://www.stackage.org/haddock/lts-12.16/text-1.2.3.1/Data-Text.html#v:stripEnd) で全ての行の末尾の空白を全部削除するように実装しました。

正直、`putStr` で出力しても、末尾の空白は見えないので不必要な感じもします。