### PR TITLE
windows の ci 修正のため PrintableString を適切に変更

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Ex04.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Ex04.hs
@@ -14,8 +14,10 @@ exercise4 = Exercise "4"
           $ runHaskellExerciseWithStdin diag4 gen4
           $ (Text.pack . unlines . reverse . lines . Text.unpack)
 
-gen4 :: (Gen [PrintableString], [PrintableString] -> [String])
-gen4 = (arbitrary, map QuickCheck.getPrintableString)
+gen4 :: (Gen [String], [String] -> [String])
+gen4 = (g, id)
+  where
+    g = QuickCheck.listOf $ QuickCheck.listOf $ QuickCheck.choose ('\33', '\126')
 
 diag4 :: Diagnosis
 diag4 code msg

--- a/src/imports/external.hs
+++ b/src/imports/external.hs
@@ -50,7 +50,7 @@ import qualified System.IO as IO
 import           System.Process.Typed (readProcess)
 import qualified System.Process.Typed as Process
 import qualified Test.QuickCheck as QuickCheck
-import           Test.QuickCheck (Arbitrary, Gen, PrintableString, Positive, quickCheckWithResult, arbitrary)
+import           Test.QuickCheck (Arbitrary, Gen, Positive, quickCheckWithResult, arbitrary)
 import qualified Text.Regex.Applicative as Regex
 import qualified Web.Browser as Browser
 #ifdef mingw32_HOST_OS


### PR DESCRIPTION
#48 

## 試したこと

- ex4 の `PrintableString` を `ASCIIString` に変更してみる。 => travis も落ちるようになった (謎)
- 制御文字を除く ascii 文字に限定

```shell
================================================================================
Your program's output: "=(\n>o9aNgF$(o&j\nb!fv\n.`WQg(0\"qN@Z\n{.\n(@#Zf@b,M.`Xuw:0'A\nO/sLoFQ\nJ)#h&['6A{$PF-@T:\n!@WC)?E2fv>rchT\n9t\n\n"
      Expected output: "=(\n>o9aNgF$(o&j\nb!fv\n.`WQg(0\"qN@Z\n{.\n(@#Zf@b,M.`Xuw:0'A\nO/sLoFQ\nJ)#h&['6A{$PF-@T:\n!@WC)?E2fv>rchT\n9t\n\n"
            For input: "\n9t\n!@WC)?E2fv>rchT\nJ)#h&['6A{$PF-@T:\nO/sLoFQ\n(@#Zf@b,M.`Xuw:0'A\n{.\n.`WQg(0\"qN@Z\nb!fv\n>o9aNgF$(o&j\n=(\n"
```