### PR TITLE
コマンドラインパーサーの導入と、open オプションの追加

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ library:
   - ghc-syntax-highlighter
   # - i18n Use in the future
   - open-browser
+  - optparse-applicative
   - QuickCheck
   - regex-applicative
   - safe

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -18,12 +18,15 @@ import Options.Applicative
 main :: IO ()
 main = do
   avoidCodingError
-  cmd <- execParser (info (cmdParser <**> helper) idm)
-  withMainEnv $ \e ->
-    case cmd of
-      Show isTerminal n -> showExercise e isTerminal [n]
-      Verify path -> verifySource e [path]
-      -- FIXME: printExerciseList
+  args <- Env.getArgs
+  if null args then
+    printExerciseList
+  else do
+    cmd <- execParser (info (cmdParser <**> helper) idm)
+    withMainEnv $ \e ->
+      case cmd of
+        Show isTerminal n -> showExercise e isTerminal [n]
+        Verify path -> verifySource e [path]
 
 
 withMainEnv :: (Env -> IO r) -> IO r
@@ -59,16 +62,16 @@ cmdParser = subparser
   <> command "verify" (info verifyCmdP (progDesc "Verify Exercise"))
 
 
--- printExerciseList :: IO ()
--- printExerciseList = do
---   Text.putStrLn "# Make Mistakes to Learn Haskell!"
---   Text.putStrLn ""
---   Text.putStrLn "## Contents"
+printExerciseList :: IO ()
+printExerciseList = do
+  Text.putStrLn "# Make Mistakes to Learn Haskell!"
+  Text.putStrLn ""
+  Text.putStrLn "## Contents"
 
---   let printHeader h = Text.putStrLn $ "- " <> h
---   mapM_ printHeader =<< Exercise.loadHeaders
+  let printHeader h = Text.putStrLn $ "- " <> h
+  mapM_ printHeader =<< Exercise.loadHeaders
 
---   Text.putStrLn $ "\nRun `" <> Text.pack appName <> " show <the exercise number>` to try the exercise."
+  Text.putStrLn $ "\nRun `" <> Text.pack appName <> " show <the exercise number>` to try the exercise."
 
 
 verifySource :: Env -> [FilePath] -> IO ()

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -30,13 +30,11 @@ withMainEnv :: (Env -> IO r) -> IO r
 withMainEnv action = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
-  loc <- maybe Browser read <$> Env.lookupEnv showExerciseOutputEnvVarName
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
     let e = defaultEnv
               { logDebug = ByteString.hPutStr h . (<> "\n")
               , appHomePath = d
               , runHaskell = RunHaskell.runFile e
-              , envShowExerciseOutputLocation = loc
               }
     action e
 

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -13,6 +13,7 @@ import qualified Education.MakeMistakesToLearnHaskell.Evaluator.RunHaskell as Ru
 import           Education.MakeMistakesToLearnHaskell.Error
 import           Education.MakeMistakesToLearnHaskell.Text
 
+import Options.Applicative
 
 main :: IO ()
 main = do
@@ -38,6 +39,26 @@ withMainEnv action = do
               , envShowExerciseOutputLocation = loc
               }
     action e
+
+data Cmd
+  = Show Bool Int
+  | Verify FilePath
+  deriving (Eq, Show)
+
+optOpenBrowserP :: Parser Bool
+optOpenBrowserP = switch $ long "open" <> help "show exercise in browser"
+
+showCmdP :: Parser Cmd
+showCmdP = Show <$> optOpenBrowserP
+                <*> argument auto (metavar "<number>")
+
+verifyCmdP :: Parser Cmd
+verifyCmdP = Verify <$> argument str (metavar "<filepath>")
+
+cmdParser :: Parser Cmd
+cmdParser = subparser
+  $  command "show" (info showCmdP (progDesc "Show Exercise"))
+  <> command "verify" (info verifyCmdP (progDesc "Verify Exercise"))
 
 
 printExerciseList :: IO ()

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -27,7 +27,7 @@ main = do
 
 
 withMainEnv :: (Env -> IO r) -> IO r
-withMainEnv action = do
+withMainEnv doAction = do
   d <- Env.getEnv homePathEnvVarName <|> Dir.getXdgDirectory Dir.XdgData appName
   Dir.createDirectoryIfMissing True d
   IO.withFile (d </> "debug.log") IO.WriteMode $ \h -> do
@@ -36,7 +36,7 @@ withMainEnv action = do
               , appHomePath = d
               , runHaskell = RunHaskell.runFile e
               }
-    action e
+    doAction e
 
 data Cmd
   = Show Bool String
@@ -59,16 +59,16 @@ cmdParser = subparser
   <> command "verify" (info verifyCmdP (progDesc "Verify Exercise"))
 
 
-printExerciseList :: IO ()
-printExerciseList = do
-  Text.putStrLn "# Make Mistakes to Learn Haskell!"
-  Text.putStrLn ""
-  Text.putStrLn "## Contents"
+-- printExerciseList :: IO ()
+-- printExerciseList = do
+--   Text.putStrLn "# Make Mistakes to Learn Haskell!"
+--   Text.putStrLn ""
+--   Text.putStrLn "## Contents"
 
-  let printHeader h = Text.putStrLn $ "- " <> h
-  mapM_ printHeader =<< Exercise.loadHeaders
+--   let printHeader h = Text.putStrLn $ "- " <> h
+--   mapM_ printHeader =<< Exercise.loadHeaders
 
-  Text.putStrLn $ "\nRun `" <> Text.pack appName <> " show <the exercise number>` to try the exercise."
+--   Text.putStrLn $ "\nRun `" <> Text.pack appName <> " show <the exercise number>` to try the exercise."
 
 
 verifySource :: Env -> [FilePath] -> IO ()
@@ -111,10 +111,10 @@ showExercise env openBrowser (n : _) = do
   d <- Exercise.loadDescriptionByName n
         >>= dieWhenNothing ("Exercise id " ++ n ++ " not found!")
   Exercise.saveLastShownName env n
-  showMarkdown env d openBrowser n
+  showMarkdown d openBrowser n
 
-showMarkdown :: Env -> Text -> Bool -> String -> IO ()
-showMarkdown env md openBrowser n = do
+showMarkdown :: Text -> Bool -> String -> IO ()
+showMarkdown md openBrowser n = do
   let htmlContent = CMark.commonmarkToHtml [CMark.optSafe] $ Text.toStrict md
       mkHtmlPath dir = dir <> "/" <> "mmlh-ex" <> n <> ".html"
   path <- mkHtmlPath <$> Dir.getTemporaryDirectory

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -21,7 +21,7 @@ main = do
   cmd <- execParser (info (cmdParser <**> helper) idm)
   withMainEnv $ \e ->
     case cmd of
-      Show openBrowser n -> showExercise e openBrowser [show n]
+      Show openBrowser n -> showExercise e openBrowser [n]
       Verify path -> verifySource e [path]
       -- FIXME: printExerciseList
 
@@ -39,7 +39,7 @@ withMainEnv action = do
     action e
 
 data Cmd
-  = Show Bool Int
+  = Show Bool String
   | Verify FilePath
   deriving (Eq, Show)
 
@@ -48,7 +48,7 @@ optOpenBrowserP = switch $ long "open" <> help "show exercise in browser"
 
 showCmdP :: Parser Cmd
 showCmdP = Show <$> optOpenBrowserP
-                <*> argument auto (metavar "<number>")
+                <*> argument str (metavar "<number>")
 
 verifyCmdP :: Parser Cmd
 verifyCmdP = Verify <$> argument str (metavar "<filepath>")

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -3,12 +3,10 @@
 module Education.MakeMistakesToLearnHaskell.Env
   ( Env (..)
   , defaultEnv
-  , ShowExerciseOutputLocation (..)
   , RunHaskellParameters(runHaskellParametersArgs, runHaskellParametersStdin)
   , defaultRunHaskellParameters
   , appName
   , homePathEnvVarName
-  , showExerciseOutputEnvVarName
   , avoidCodingError
   )
 where
@@ -30,13 +28,7 @@ data Env = Env
   , appHomePath :: FilePath
   , runHaskell :: RunHaskellParameters -> IO (Either RunHaskellError (ByteString, ByteString))
   , envQcMaxSuccessSize :: Int
-  , envShowExerciseOutputLocation :: ShowExerciseOutputLocation -- ^ mmlh show コマンドの出力先
   }
-
-data ShowExerciseOutputLocation
-  = Browser
-  | Terminal
-  deriving (Eq, Show, Read)
 
 defaultEnv :: Env
 defaultEnv = Env
@@ -44,7 +36,6 @@ defaultEnv = Env
   , appHomePath = error "Set appHomePath to defaultEnv"
   , runHaskell = error "Set runHaskell to defaultEnv"
   , envQcMaxSuccessSize = 20
-  , envShowExerciseOutputLocation = Browser
   }
 
 appName :: String
@@ -53,10 +44,6 @@ appName = "mmlh"
 
 homePathEnvVarName :: String
 homePathEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_HOME"
-
-showExerciseOutputEnvVarName :: String
-showExerciseOutputEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_SHOW_EXERCISE_OUTPUT_LOCATION"
-
 
 avoidCodingError :: IO ()
 #ifdef mingw32_HOST_OS

--- a/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
+++ b/test/Education/MakeMistakesToLearnHaskell/SpecEnv.hs
@@ -16,7 +16,6 @@ mkDefaultSpecEnv = runIO $ do
             { logDebug = const $ return ()
             -- { logDebug = ByteString.putStrLn
             , appHomePath = tmpDir
-            , envShowExerciseOutputLocation = Terminal
             }
 
 

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -53,9 +53,7 @@ spec =
 runMmlh :: [String] -> IO ProcessResult
 runMmlh args = do
   Dir.createDirectoryIfMissing False "./tmp/"
-  let env = [ (homePathEnvVarName, Just "./tmp/")
-            , (showExerciseOutputEnvVarName, Just (show Terminal))
-            ]
+  let env = [ (homePathEnvVarName, Just "./tmp/")]
   withArgs args
     $ withEnv env
     $ captureProcessResult Education.MakeMistakesToLearnHaskell.main


### PR DESCRIPTION
#61 

- `mmlh show` の出力先を環境変数で切り替えていたが、微妙なのでコマンドラインパーサーを導入することになった。
- [optparse-applicative](https://www.stackage.org/lts-12.16/package/optparse-applicative-0.14.3.0) を利用
- Main 以外で定義しないような気がするので  `import` は直接 `src/Education/MakeMistakesToLearnHaskell.hs` で行いました。

@igrep 
なぜか以下のテストで落ちるようになってしまっているので、直します。

```
test/Education/MakeMistakesToLearnHaskellSpec.hs:84:3:
  1) Education.MakeMistakesToLearnHaskell, mmlh verify, given non-existing answer of exercise 2.5, show NOT VERIFIED
       expected: Nothing
        but got: Just "non-existing: openFile: does not exist (No such file or directory)"
```