### PR TITLE
SUCCESS, FAILを色付きで表示する

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ library:
   dependencies:
   - base >=4.7 && <5
   # TODO: Decide version
+  - ansi-terminal
   - QuickCheck
   - bytestring
   - cmark

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -14,6 +14,7 @@ import           Education.MakeMistakesToLearnHaskell.Error
 import           Education.MakeMistakesToLearnHaskell.Text
 
 import qualified Options.Applicative as Opt
+import           System.Console.ANSI
 
 main :: IO ()
 main = do
@@ -83,17 +84,15 @@ verifySource e (file : _) = do
   case result of
       Exercise.Success details -> do
         Text.putStrLn details
-        putStrLn "\n\nSUCCESS: Congratulations! Your solution got compiled and ran correctly!"
+        withSGR [SetColor Foreground Vivid Green] $
+          putStrLn "\n\nSUCCESS: Congratulations! Your solution got compiled and ran correctly!"
         putStrLn "Here's an example solution of this exercise:\n"
         Text.putStr =<< Exercise.loadExampleSolution currentExercise
         Exit.exitSuccess
       Exercise.Fail details -> do
-        mapM_ Text.putStrLn
-          [ details
-          , ""
-          , "FAIL: Your solution didn't pass. Try again!"
-          , ""
-          ]
+        Text.putStrLn details
+        withSGR [SetColor Foreground Vivid Red] $
+          putStrLn "\nFAIL: Your solution didn't pass. Try again!\n"
         Exit.exitFailure
       Exercise.Error details -> do
         Error.errLn $ Text.toStrict $ details <> "\n\n"
@@ -106,6 +105,8 @@ verifySource e (file : _) = do
         putStrLn "Here's an example solution of this exercise:\n"
         Text.putStr =<< Exercise.loadExampleSolution currentExercise
         Exit.exitSuccess
+  where
+    withSGR sgrs action = setSGR sgrs >> action >> setSGR [Reset]
 
 
 showExercise :: Env -> Bool -> [String] -> IO ()

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -106,7 +106,7 @@ verifySource e (file : _) = do
         Text.putStr =<< Exercise.loadExampleSolution currentExercise
         Exit.exitSuccess
   where
-    withSGR sgrs action = setSGR sgrs >> action >> setSGR [Reset]
+    withSGR sgrs act = setSGR sgrs >> act >> setSGR [Reset]
 
 
 showExercise :: Env -> Bool -> [String] -> IO ()


### PR DESCRIPTION
```
shell> mmlh verify
```
のときにSUCCESS, FAILに色がついてたら見やすいかなと思って実装してみました。

ご意見・レビューいただけると 🙏 

## Before

![image](https://user-images.githubusercontent.com/7668186/48266754-babb2900-e473-11e8-8405-1e35a40ab856.png)

## After

![image](https://user-images.githubusercontent.com/7668186/48266846-fce46a80-e473-11e8-936a-e68fa7ed71bd.png)
