### PR TITLE
GHCの出力に無関係な文字列を含めないように修正

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -79,7 +79,6 @@ verifySource _ [] = die "Specify the Haskell source file to veirfy!"
 verifySource e (file : _) = do
   currentExercise <- Exercise.loadLastShown e
   result <- Exercise.verify currentExercise e file
-  putStrLn "==================== GHC output ===================="
   case result of
       Exercise.Success details -> do
         Text.putStrLn details

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Core.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Core.hs
@@ -53,6 +53,7 @@ runHaskellExercise' mParam diag right e prgFile = do
             then Success $ "Nice output!\n\n" <> msg
             else Fail $ "Wrong output!\n\n" <> msg
       Left err -> do
+        putStrLn "==================== GHC output ===================="
         case err of
             RunHaskell.RunHaskellNotFound ->
               return $ Error "runhaskell command is not available.\nInstall stack or Haskell Platform."


### PR DESCRIPTION
#67
`GHC` のエラーは `Left` の時しか無いと思うので、そっちで出力するように移動しました。

```shell
$ stack run verify assets/1.hs
Nice output!

================================================================================
Your program's output: "Hello, world!\n"
      Expected output: "Hello, world!\n"



SUCCESS: Congratulations! Your solution got compiled and ran correctly!
Here's an example solution of this exercise:

main = putStrLn "Hello, world!"
```

```shell
$ stack run verify test/assets/1/no-main.hs
==================== GHC output ====================

test/assets/1/no-main.hs:1:1: error:
    Parse error: module header, import declaration
    or top-level declaration expected.
  |
1 | putStrLn "Hello, world!"
  | ^^^^^^^^^^^^^^^^^^^^^^^^

==================== mmlh HINT output ====================

HINT: This error indicates you haven't defined main function.

FAIL: Your solution didn't pass. Try again!
```