### PR TITLE
Fix 72: Add exercise number to the output of `mmlh verify` 

### DIFF
--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -113,7 +113,7 @@ verifySource e (file : _) = do
         showExampleSolution currentExercise
         Exit.exitSuccess
   where
-    withSGR sgrs act = setSGR sgrs >> act >> setSGR [Reset]
+    withSGR sgrs act = bracket_ (setSGR sgrs) (setSGR [Reset]) act
 
     showExampleSolution ex = do
         putStrLn $ "Here's an example solution of the exercise " ++ Exercise.name ex ++ ":\n"

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -85,27 +85,39 @@ verifySource e (file : _) = do
         Text.putStrLn details
         withSGR [SetColor Foreground Vivid Green] $
           putStrLn "\n\nSUCCESS: Congratulations! Your solution got compiled and ran correctly!"
-        putStrLn "Here's an example solution of this exercise:\n"
-        Text.putStr =<< Exercise.loadExampleSolution currentExercise
+
+        showExampleSolution currentExercise
         Exit.exitSuccess
+
       Exercise.Fail details -> do
         Text.putStrLn details
         withSGR [SetColor Foreground Vivid Red] $
-          putStrLn "\nFAIL: Your solution didn't pass. Try again!\n"
+          putStrLn "\nFAIL: Your solution didn't pass. Try again!"
+        putStrLn $ "HINT: Verified the exercise " ++ Exercise.name currentExercise ++ ". Note I verify the last `mmlh show`-ed exercise.\n"
         Exit.exitFailure
+
       Exercise.Error details -> do
         Error.errLn $ Text.toStrict $ details <> "\n\n"
         die "An unexpected error occurred when evaluating your solution."
+
       Exercise.NotVerified -> do
-        Text.putStrLn "[NOT VERIFIED] This exercise has no test. Go ahead!"
+        putStrLn $ "[NOT VERIFIED] the exercise " ++ Exercise.name currentExercise ++ " has no test. Go ahead!"
         Exit.exitSuccess
+
       Exercise.NotYetImplemented -> do
-        Text.putStrLn "[NOT YET IMPLEMENTED] Sorry, this exercise's test is not yet implemented. Check by yourself!"
-        putStrLn "Here's an example solution of this exercise:\n"
-        Text.putStr =<< Exercise.loadExampleSolution currentExercise
+        putStrLn
+          $ "[NOT YET IMPLEMENTED] Sorry, the test of exercise "
+          ++ Exercise.name currentExercise
+          ++ " is not yet implemented. Check by yourself!"
+
+        showExampleSolution currentExercise
         Exit.exitSuccess
   where
     withSGR sgrs act = setSGR sgrs >> act >> setSGR [Reset]
+
+    showExampleSolution ex = do
+        putStrLn $ "Here's an example solution of the exercise " ++ Exercise.name ex ++ ":\n"
+        Text.putStr =<< Exercise.loadExampleSolution ex
 
 
 showExercise :: Env -> Bool -> [String] -> IO ()

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Education.MakeMistakesToLearnHaskell.Exercise
-  ( Exercise(verify)
+  ( Exercise(verify, name)
   , Name
   , Result(..)
   , Details
@@ -37,7 +37,7 @@ import Education.MakeMistakesToLearnHaskell.Exercise.Ex04
 import Education.MakeMistakesToLearnHaskell.Exercise.Ex05
 
 exercises :: [(Name, Exercise)]
-exercises = map (\e -> (exerciseName e, e))
+exercises = map (\e -> (name e, e))
   [ exercise1
   , exercise2
   , exercise2_5
@@ -52,14 +52,14 @@ loadHeaders = mapM (loadHeader . snd) exercises
     loadHeader ex = extractHeader ex =<< loadDescription ex
 
     extractHeader ex desc =
-      dieWhenNothing ("The description of exercise '" ++ exerciseName ex ++ "' is empty!")
+      dieWhenNothing ("The description of exercise '" ++ name ex ++ "' is empty!")
         $ appendName ex . cutHash <$> headMay (Text.lines desc)
 
     cutHash h =
       Text.strip $ fromMaybe h $ Text.stripPrefix "# " h
 
     appendName ex h =
-      Text.pack (exerciseName ex) <> ": " <> h
+      Text.pack (name ex) <> ": " <> h
 
 
 loadDescription :: Exercise -> IO Text
@@ -72,7 +72,7 @@ loadExampleSolution = loadWithExtension ".hs"
 
 loadWithExtension :: String -> Exercise -> IO Text
 loadWithExtension ext ex =
-  Paths.getDataFileName ("assets/" ++ exerciseName ex ++ ext)
+  Paths.getDataFileName ("assets/" ++ name ex ++ ext)
     >>= readUtf8File
 
 

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
@@ -9,7 +9,7 @@ import           Education.MakeMistakesToLearnHaskell.Env
 
 data Exercise =
   Exercise
-    { exerciseName :: !Name
+    { name :: !Name
     -- ^ The name of the exercise.
     , verify :: Env -> String -> IO Result
     -- ^ The function to verify the source file, project directory,


### PR DESCRIPTION
Fix #72 
https://github.com/haskell-jp/makeMistakesToLearnHaskell/pull/76 で修正案を出していただいた後で申し訳ないですが、もう少しいい方法が思いついたので私が修正しました。

今回の問題によってユーザーが特に混乱しそうな、意図しない `FAILED` が出たときにわかりやすく課題の番号が出るよう修正しました。
その他の結果でも課題番号は出しますが、さほど重要ではないはずなのでメッセージ内にそれとなく含めています。
以下出力例です。

```
> stack exec mmlh verify .\assets\1.hs
Wrong output!

================================================================================
Your program's output: "Hello, world!\n"
      Expected output: "20.761245674740486\n"


FAIL: Your solution didn't pass. Try again!
HINT: Verified the exercise 2. Note I verify the last `mmlh show`-ed exercise.
```

ついでに、端末の色は確実にresetすべきだと思うので `bracket_` で囲っておきました。