### PR TITLE
Enhance exercise 3

### DIFF
--- a/assets/3.md
+++ b/assets/3.md
@@ -25,10 +25,9 @@ Haskellの文字列リテラルは、改行文字を直接含めることがで�
 
 ```haskell
 ghci>  "newline here:
-| after newline"
-|
-<interactive>:2:5: error:
-    lexical error in string/character literal at character '\n'
+
+<interactive>:11:5: error:
+    lexical error in string/character literal at end of input
 ```
 
 文字列リテラルの中での改行は、必ず `\n` というバックスラッシュ（環境によっては円マークに見えるかも知れません）で始まる、エスケープシーケンスを使用してください。  
@@ -91,6 +90,12 @@ test\assets\3\no-do.hs:2:3: error:
 
 という箇所から、「`putStrLn`に渡した引数が多すぎる」ということが読み取れるでしょうか？  
 つまりHaskellは、最初の`putStrLn`に対して、`"newline here:"`, `putStrLn`, `"after newline"`という、3つの引数を渡した、と解釈したようです。  
+つまり、他のプログラミング言語の構文で例えると、下記のように`putStrLn`関数を呼び出した、と解釈したのです。
+
+```
+putStrLn("newline here:", putStrLn, "after newline")
+```
+
 実際にはこれまでに使ってきたとおり、`putStrLn`は1つの引数しか受け取らない関数なので、これではエラーになってしまいます。
 
 このエラーを解決する（一つの）方法が、`do`記法です。  
@@ -120,6 +125,37 @@ main = do
   putStrLn "え"
   putStrLn "お"
 ```
+
+#### GHCi上で`do`記法を試す
+
+ここまで読んですでに試した方もいらっしゃるかと思うので紹介しておきましょう。  
+GHCi上で`do`記法をそのまま入力しようとすると、下記のようなエラーになります。
+
+```haskell
+ghci> do
+
+<interactive>:4:1: error: Empty 'do' block
+```
+
+これを回避する方法はいくつかありますが、ここでは一番使いやすい`:set +m`を使った方法を紹介します。
+
+GHCiの設定を変えるコマンド`:set`に`+m`という引数を渡すと、複数行のコマンドが入力できるようになります。
+
+```
+ghci> :set +m
+ghci| do
+ghci| putStrLn "aaa"
+ghci| putStrLn "bbb"
+ghci|
+aaa
+bbb
+```
+
+※上記の`ghci| `という表記は、行の続きを入力する際に表示されるプロンプトです。`ghci> `と同様、設定によって違う表示になるかと思います。
+
+入力を終了させたい場合は、空行を入力してください。
+
+`:set +m`を毎回入力するのが面倒だ、という場合は、`~/.ghci`というファイルに、`:set +m`を追記しましょう。
 
 ## 課題の解き方
 


### PR DESCRIPTION
- Correct error message with the one by the default GHCi.
- Explain that `putStrLn` is called with three arguments, with the function calling of the other programming languages.
- Show how to try `do` syntax on GHCi.