### PR TITLE
Issue101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .stack-work/
 cabal-helper*.build
 /tmp/
+/dist/
 
 *.exe
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ cabal-helper*.build
 *.exe
 *.o
 *.hi
-*.cabal
+/makeMistakesToLearnHaskell.cabal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-RUN apt-get update -y && apt-get install libgmp10 -y && apt-get clean -y
+RUN apt-get update -y && apt-get install libgmp10 git -y && apt-get clean -y
 RUN mkdir -p /opt/mmlh-reporter/
 
 # NOTE: The executable file must be built on the same distribution. I omit to build on the container!

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,3 @@ RUN mkdir -p /opt/mmlh-reporter/
 COPY ./dist/mmlh-reporter /opt/mmlh-reporter/
 
 WORKDIR /opt/mmlh-reporter/
-
-ENTRYPOINT /opt/mmlh-reporter/mmlh-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stable-slim
+
+RUN apt-get update -y && apt-get install libgmp10 -y && apt-get clean -y
+RUN mkdir -p /opt/mmlh-reporter/
+
+# NOTE: The executable file must be built on same OS. I omit to build on the container!
+COPY ./dist/mmlh-reporter /opt/mmlh-reporter/
+
+WORKDIR /opt/mmlh-reporter/
+
+ENTRYPOINT /opt/mmlh-reporter/mmlh-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM debian:stable-slim
 RUN apt-get update -y && apt-get install libgmp10 -y && apt-get clean -y
 RUN mkdir -p /opt/mmlh-reporter/
 
-# NOTE: The executable file must be built on same OS. I omit to build on the container!
+# NOTE: The executable file must be built on the same distribution. I omit to build on the container!
 COPY ./dist/mmlh-reporter /opt/mmlh-reporter/
 
 WORKDIR /opt/mmlh-reporter/
+
+ENTRYPOINT /opt/mmlh-reporter/mmlh-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY ./dist/mmlh-reporter /opt/mmlh-reporter/
 
 WORKDIR /opt/mmlh-reporter/
 
-ENTRYPOINT /opt/mmlh-reporter/mmlh-reporter
+CMD /opt/mmlh-reporter/mmlh-reporter

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,4 +5,4 @@ import qualified Education.MakeMistakesToLearnHaskell
 
 
 main :: IO ()
-main = Education.MakeMistakesToLearnHaskell.main
+main = Education.MakeMistakesToLearnHaskell.productionMain

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,13 +23,14 @@ environment:
     TMP: "c:\\tmp"
 
 cache:
+- '%LOCALAPPDATA%\Programs\stack\'
 - "c:\\sr"
 
 test_script:
 - chcp 65001
 - stack setup > nul
-# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
-# descriptor
 - stack build --jobs zlib
 - chcp 932
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
 - echo "" | stack --no-terminal test --jobs 1 --pedantic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,6 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
+- stack build --jobs zlib
+- chcp 932
 - echo "" | stack --no-terminal test --jobs 1 --pedantic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ cache:
 test_script:
 - chcp 65001
 - stack setup > nul
-- stack build --jobs zlib
+- stack build --jobs 1 zlib
 - chcp 932
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ cache:
 - "c:\\sr"
 
 test_script:
-- chcp 932
+- chcp 65001
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,8 @@ cache:
 - "c:\\sr"
 
 test_script:
-- chcp 65001
-- stack setup > nul
-- stack build --jobs 1 zlib
 - chcp 932
+- stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --no-terminal test --jobs 1 --pedantic
+- echo "" | stack --no-interleaved-output --no-terminal test --jobs 1 --pedantic

--- a/build-mmlh-reporter.sh
+++ b/build-mmlh-reporter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+stack --local-bin-path=./dist/ install mmlh-reporter:mmlh-reporter
+sudo docker build --network=host -tmmlh-reporter:latest .

--- a/commons/LICENSE
+++ b/commons/LICENSE
@@ -1,0 +1,30 @@
+Copyright Author name here (c) 2019
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/commons/README.md
+++ b/commons/README.md
@@ -1,0 +1,1 @@
+# mmlh-commons

--- a/commons/Setup.hs
+++ b/commons/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/commons/mmlh-commons.cabal
+++ b/commons/mmlh-commons.cabal
@@ -1,0 +1,27 @@
+name:                mmlh-commons
+version:             0.1.0.0
+-- synopsis:
+-- description:
+homepage:            https://github.com/haskell-jp/makeMistakesToLearnHaskell/tree/master/commons#readme
+license:             Apache-2.0
+license-file:        LICENSE
+author:              Japan Haskell User Group
+maintainer:          Yuji Yamamoto <whosekiteneverfly@gmail.com>
+copyright:           2019 Japan Haskell User Group
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+      Education.MakeMistakesToLearnHaskell.Commons.Exercise
+  build-depends:       base >= 4.7 && < 5
+                     , aeson
+                     , text
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell-jp/makeMistakesToLearnHaskell

--- a/commons/src/Education/MakeMistakesToLearnHaskell/Commons/Exercise.hs
+++ b/commons/src/Education/MakeMistakesToLearnHaskell/Commons/Exercise.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Education.MakeMistakesToLearnHaskell.Commons.Exercise where
+
+import qualified Data.Aeson.TH  as AT
+import           Data.Text.Lazy (Text)
+
+
+type Details = Text
+
+type SourceCode = Text
+
+type Name = String
+
+
+data FailBy =
+    WrongOutput !Details
+  | CommandFailed
+      !FilePath   -- ^ Command name
+      !Details -- ^ Output by command
+      !Details -- ^ Diagnosis message
+  deriving (Eq, Show)
+
+$(AT.deriveJSON AT.defaultOptions ''FailBy)

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: ''
+  web: 'dummy'

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: '/opt/mmlh-reporter/mmlh-reporter'
+  web: ''

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,5 @@
 build:
   docker:
     web: Dockerfile
+run:
+  web: []

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: []
+  web: '/opt/mmlh-reporter/mmlh-reporter'

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ library:
   dependencies:
   - base >=4.7 && <5
   - mmlh-commons
+  - mmlh-reporter
   # TODO: Decide version
   - ansi-terminal
   - QuickCheck
@@ -92,6 +93,7 @@ tests:
     dependencies:
     - base
     - makeMistakesToLearnHaskell
+    - mmlh-reporter
     - bytestring
     - directory
     - filepath

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ library:
   # Why doesn't -Wno-unused-imports work?
   dependencies:
   - base >=4.7 && <5
+  - mmlh-commons
   # TODO: Decide version
   - ansi-terminal
   - QuickCheck

--- a/reporter/LICENSE
+++ b/reporter/LICENSE
@@ -1,0 +1,13 @@
+Copyright Japan Haskell User Group (c) 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -1,0 +1,3 @@
+# makeMistakesToLearnHaskell Reporter
+
+

--- a/reporter/Setup.hs
+++ b/reporter/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/reporter/app/client.hs
+++ b/reporter/app/client.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Control.Exception                                     (throwIO)
+import           Control.Monad.IO.Class                                (liftIO)
+import qualified Data.Text.Lazy                                        as T
+import qualified Data.Text.Lazy.IO                                     as TI
+import           GHC.Generics                                          (Generic)
+import           Network.HTTP.Client                                   (defaultManagerSettings,
+                                                                        newManager)
+-- import           Servant.API
+import           Options.Generic                                       (ParseRecord,
+                                                                        getRecord)
+import           Servant.Client                                        (ClientM,
+                                                                        client,
+                                                                        mkClientEnv,
+                                                                        parseBaseUrl,
+                                                                        runClientM)
+
+import qualified Education.MakeMistakesToLearnHaskell.Commons.Exercise as Exercise
+import           Education.MakeMistakesToLearnHaskell.Report.Server    (Report (..),
+                                                                        Result,
+                                                                        api,
+                                                                        reportUrl)
+
+
+data Args = Args
+  { endpoint :: !String
+  , name     :: !String
+  , answer   :: !T.Text
+  , details  :: !T.Text
+  } deriving (Generic, Show)
+
+instance ParseRecord Args
+
+postReport :: Report -> ClientM Result
+postReport = client api
+
+
+main :: IO ()
+main = do
+  manager <- newManager defaultManagerSettings
+  args <- getRecord "Post report"
+  env <- mkClientEnv manager <$> parseBaseUrl (endpoint args)
+  let r = Report
+        { exerciseName = name args
+        , exerciseAnswer = answer args
+        , exerciseFailBy = Exercise.WrongOutput $ details args
+        }
+  either throwIO return =<< runClientM (liftIO . TI.putStrLn . reportUrl =<< postReport r) env

--- a/reporter/app/client.hs
+++ b/reporter/app/client.hs
@@ -11,6 +11,7 @@ import           Network.HTTP.Client                                   (defaultM
 -- import           Servant.API
 import           Options.Generic                                       (ParseRecord,
                                                                         getRecord)
+import           Servant.API                                           ((:<|>) ((:<|>)))
 import           Servant.Client                                        (ClientM,
                                                                         client,
                                                                         mkClientEnv,
@@ -34,7 +35,7 @@ data Args = Args
 instance ParseRecord Args
 
 postReport :: Report -> ClientM Result
-postReport = client api
+_ :<|> postReport = client api
 
 
 main :: IO ()

--- a/reporter/app/client.hs
+++ b/reporter/app/client.hs
@@ -6,9 +6,8 @@ import           Control.Monad.IO.Class                                (liftIO)
 import qualified Data.Text.Lazy                                        as T
 import qualified Data.Text.Lazy.IO                                     as TI
 import           GHC.Generics                                          (Generic)
-import           Network.HTTP.Client                                   (defaultManagerSettings,
-                                                                        newManager)
--- import           Servant.API
+import           Network.HTTP.Client                                   (newManager)
+import           Network.HTTP.Client.TLS                               (tlsManagerSettings)
 import           Options.Generic                                       (ParseRecord,
                                                                         getRecord)
 import           Servant.API                                           ((:<|>) ((:<|>)))
@@ -40,7 +39,7 @@ _ :<|> postReport = client api
 
 main :: IO ()
 main = do
-  manager <- newManager defaultManagerSettings
+  manager <- newManager tlsManagerSettings
   args <- getRecord "Post report"
   env <- mkClientEnv manager <$> parseBaseUrl (endpoint args)
   let r = Report

--- a/reporter/app/server.hs
+++ b/reporter/app/server.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import           Education.MakeMistakesToLearnHaskell.Report.Server
+
+main :: IO ()
+main = startApp

--- a/reporter/mmlh-reporter.cabal
+++ b/reporter/mmlh-reporter.cabal
@@ -1,0 +1,72 @@
+name:                mmlh-reporter
+version:             0.1.0.0
+-- synopsis:
+-- description:
+homepage:            https://github.com/haskell-jp/makeMistakesToLearnHaskell/tree/master/reporter#readme
+license:             Apache-2.0
+license-file:        LICENSE
+author:              Japan Haskell User Group
+maintainer:          Yuji Yamamoto <whosekiteneverfly@gmail.com>
+copyright:           2019 Japan Haskell User Group
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Education.MakeMistakesToLearnHaskell.Report.Server
+                     , Education.MakeMistakesToLearnHaskell.Report.Client
+  build-depends:       base >= 4.7 && < 5
+                     , aeson
+                     , bytestring
+                     , directory
+                     , filelock
+                     , http-client
+                     , http-client-tls
+                     , mmlh-commons
+                     , servant
+                     , servant-client
+                     , servant-server
+                     , text
+                     , typed-process
+                     , ulid
+                     , wai
+                     , warp
+  default-language:    Haskell2010
+
+executable mmlh-reporter
+  hs-source-dirs:      app
+  main-is:             server.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , mmlh-reporter
+  default-language:    Haskell2010
+
+executable mmlh-reporter-test-client
+  hs-source-dirs:      app
+  main-is:             client.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , mmlh-reporter
+                     , mmlh-commons
+                     , optparse-generic
+                     , text
+  default-language:    Haskell2010
+
+test-suite mmlh-reporter-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , mmlh-reporter
+                     , hspec
+                     , hspec-wai
+                     , hspec-wai-json
+                     , aeson
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell-jp/makeMistakesToLearnHaskell

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Client.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Client.hs
@@ -1,0 +1,34 @@
+module Education.MakeMistakesToLearnHaskell.Report.Client
+  ( Report (..)
+  , Result (..)
+  , postReport
+  , EndpointUrl
+  , ReportClientError
+  ) where
+
+import           Network.HTTP.Client                                (newManager)
+import           Network.HTTP.Client.TLS                            (tlsManagerSettings)
+import           Servant.API                                        ((:<|>) ((:<|>)))
+import           Servant.Client                                     (ClientM, ServantError,
+                                                                     client,
+                                                                     mkClientEnv,
+                                                                     parseBaseUrl,
+                                                                     runClientM)
+
+import           Education.MakeMistakesToLearnHaskell.Report.Server (Report (..),
+                                                                     Result (..),
+                                                                     api)
+
+type EndpointUrl = String
+
+type ReportClientError = ServantError
+
+postReportM :: Report -> ClientM Result
+_ :<|> postReportM = client api
+
+
+postReport :: EndpointUrl -> Report -> IO (Either ReportClientError Result)
+postReport url r = do
+  manager <- newManager tlsManagerSettings
+  env <- mkClientEnv manager <$> parseBaseUrl url
+  runClientM (postReportM r) env

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -59,7 +59,10 @@ type GithubAccessToken = String
 
 
 startApp :: IO ()
-startApp = run 8080 =<< app <$> getEnv "GITHUB_ACCESS_TOKEN"
+startApp = do
+  a <- app <$> getEnv "GITHUB_ACCESS_TOKEN"
+  p <- read <$> getEnv "PORT"
+  run p a
 
 
 app :: GithubAccessToken -> Application

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -5,12 +5,13 @@
 {-# LANGUAGE TypeOperators     #-}
 module Education.MakeMistakesToLearnHaskell.Report.Server
     ( Report (..)
-    , Result
-    , reportUrl
+    , Result (..)
     , API
     , startApp
     , app
     , api
+
+    , startStub
     ) where
 
 import           Control.Monad                                         (unless)
@@ -73,6 +74,10 @@ startApp = do
   run p app
 
 
+startStub :: Int -> IO ()
+startStub port = run port $ serve api stubServer
+
+
 app :: Application
 app = serve api server
 
@@ -83,6 +88,18 @@ api = Proxy
 
 server :: Server API
 server = pong :<|> postReport
+
+
+stubServer :: Server API
+stubServer = stubPong :<|> stubPostReport
+
+
+stubPong :: Handler T.Text
+stubPong = return "STUB SERVER: It works!\n"
+
+
+stubPostReport :: Report -> Handler Result
+stubPostReport r = return . Result . T.pack $ show r
 
 
 pong :: Handler T.Text

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -52,7 +52,9 @@ newtype Result = Result { reportUrl :: T.Text } deriving (Eq, Show)
 $(AT.deriveJSON AT.defaultOptions ''Result)
 
 
-type API = "reports" :> ReqBody '[JSON] Report :> Post '[JSON] Result
+type API =
+  Get '[PlainText] T.Text
+    :<|> "reports" :> ReqBody '[JSON] Report :> Post '[JSON] Result
 
 
 type GithubAccessToken = String
@@ -74,7 +76,11 @@ api = Proxy
 
 
 server :: GithubAccessToken -> Server API
-server = postReport
+server tok = pong :<|> postReport tok
+
+
+pong :: Handler T.Text
+pong = return "It works!"
 
 
 postReport :: GithubAccessToken -> Report -> Handler Result

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeOperators     #-}
+module Education.MakeMistakesToLearnHaskell.Report.Server
+    ( Report (..)
+    , Result
+    , reportUrl
+    , API
+    , startApp
+    , app
+    , api
+    ) where
+
+import           Control.Monad                                         (unless)
+import           Control.Monad.IO.Class                                (MonadIO,
+                                                                        liftIO)
+import qualified Data.Aeson.TH                                         as AT
+import qualified Data.ByteString.Lazy                                  as B
+import qualified Data.Text.Lazy                                        as T
+import qualified Data.Text.Lazy.Encoding                               as TE
+import qualified Data.Text.Lazy.IO                                     as TI
+import qualified Data.ULID                                             as U
+import           GHC.Generics                                          (Generic)
+import           Network.Wai
+import           Network.Wai.Handler.Warp
+import           Servant
+import           System.Directory                                      (createDirectory,
+                                                                        doesDirectoryExist,
+                                                                        doesFileExist,
+                                                                        withCurrentDirectory,
+                                                                        withCurrentDirectory)
+import           System.Environment                                    (getEnv)
+import qualified System.FileLock                                       as FL
+import qualified System.Process.Typed                                  as P
+
+import qualified Education.MakeMistakesToLearnHaskell.Commons.Exercise as Exercise
+
+
+data Report = Report
+  { exerciseName   :: Exercise.Name
+  , exerciseAnswer :: Exercise.SourceCode
+  , exerciseFailBy :: Exercise.FailBy
+  } deriving (Eq, Show, Generic)
+
+$(AT.deriveJSON AT.defaultOptions ''Report)
+
+
+newtype Result = Result { reportUrl :: T.Text } deriving (Eq, Show)
+
+$(AT.deriveJSON AT.defaultOptions ''Result)
+
+
+type API = "reports" :> ReqBody '[JSON] Report :> Post '[JSON] Result
+
+
+type GithubAccessToken = String
+
+
+startApp :: IO ()
+startApp = run 8080 =<< app <$> getEnv "GITHUB_ACCESS_TOKEN"
+
+
+app :: GithubAccessToken -> Application
+app = serve api . server
+
+
+api :: Proxy API
+api = Proxy
+
+
+server :: GithubAccessToken -> Server API
+server = postReport
+
+
+postReport :: GithubAccessToken -> Report -> Handler Result
+postReport at r = liftIO $ do
+  e <- doesDirectoryExist $ repositoryName ++ "/.git"
+  unless e $
+    runGit_ ["clone", "--depth", "1", "--branch", "reports", repositoryUrl at]
+
+  withCurrentDirectory repositoryName . locking $ do
+    createReportCommitToGithub r
+    runGit_ ["push", "-u"]
+    resultFromSha <$> getHeadSha
+
+
+createReportCommitToGithub :: MonadIO m => Report -> m ()
+createReportCommitToGithub r = liftIO $ do
+  dname <- show <$> U.getULID
+  createDirectory dname
+  withCurrentDirectory dname $ do
+    TI.writeFile "answer.hs" $ exerciseAnswer r
+    writeFailBy $ exerciseFailBy r
+    runGit_ ["add", "."]
+    runGit_ ["commit", "-m", "Exercise " ++ exerciseName r]
+
+
+writeFailBy :: Exercise.FailBy -> IO ()
+writeFailBy (Exercise.WrongOutput d) =
+  TI.writeFile "wrong-output.details.txt" d
+writeFailBy (Exercise.CommandFailed cmd dCmd dDiag) = do
+  TI.writeFile (cmd ++ ".output.txt") dCmd
+  TI.writeFile "diagnosis.txt" dDiag
+
+
+getHeadSha :: MonadIO m => m T.Text
+getHeadSha = do
+  (out, err) <- P.readProcess_ $ P.proc "git" ["rev-parse", "HEAD"]
+  liftIO $ B.putStr err
+  return $ TE.decodeUtf8 out
+
+
+locking :: IO a -> IO a
+locking act = do
+  let lockFile = ".mmlh-report-server.lock"
+  e <- doesFileExist lockFile
+  unless e $ writeFile lockFile ""
+  FL.withFileLock lockFile FL.Exclusive (const act)
+
+
+resultFromSha :: T.Text -> Result
+resultFromSha = Result . ("https://github.com/haskell-jp-bot/makeMistakesToLearnHaskell-support/commit/" <>)
+
+
+runGit_ :: MonadIO m => [String] -> m ()
+runGit_ = P.runProcess_ . P.proc "git"
+
+
+repositoryName :: FilePath
+repositoryName = "makeMistakesToLearnHaskell-support"
+
+
+repositoryUrl :: GithubAccessToken -> String
+repositoryUrl at =
+  "https://haskell-jp-bot:" ++ at ++ "@github.com/haskell-jp-bot/" ++ repositoryName ++ ".git"

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -80,7 +80,7 @@ server tok = pong :<|> postReport tok
 
 
 pong :: Handler T.Text
-pong = return "It works!"
+pong = return "It works!\n"
 
 
 postReport :: GithubAccessToken -> Report -> Handler Result

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -83,6 +83,9 @@ pong = return "It works!\n"
 
 postReport :: GithubAccessToken -> Report -> Handler Result
 postReport at r = liftIO $ do
+  runGit_ ["config", "--global user.email", "whosekiteneverfly+haskelljp@gmail.com"]
+  runGit_ ["config", "--global user.name", "Haskell-jp Bot"]
+
   e <- doesDirectoryExist $ repositoryName ++ "/.git"
   unless e $
     runGit_ ["clone", "--depth", "1", repositoryUrl at]

--- a/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
+++ b/reporter/src/Education/MakeMistakesToLearnHaskell/Report/Server.hs
@@ -62,7 +62,7 @@ type GithubAccessToken = String
 startApp :: IO ()
 startApp = do
   at <- getEnv "GITHUB_ACCESS_TOKEN"
-  p <- read <$> getEnv "PORT"
+  p <- read <$> getEnv "PORT" -- Apps running on Heroku must read the port number by this envvar.
 
   runGit_ ["config", "--global", "user.email", "whosekiteneverfly+haskelljp@gmail.com"]
   runGit_ ["config", "--global", "user.name", "Haskell-jp Bot"]

--- a/reporter/test/Spec.hs
+++ b/reporter/test/Spec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+module Main (main) where
+
+{-
+import           Education.MakeMistakesToLearnHaskell.Report.Server (app)
+
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
+-}
+
+main :: IO ()
+main = putStrLn "No tests so far! sorry!" -- hspec spec
+
+{-
+spec :: Spec
+spec = with (return app) $ do
+    describe "GET /users" $ do
+        it "responds with 200" $ do
+            get "/users" `shouldRespondWith` 200
+        it "responds with [User]" $ do
+            let users = "[{\"userId\":1,\"userFirstName\":\"Isaac\",\"userLastName\":\"Newton\"},{\"userId\":2,\"userFirstName\":\"Albert\",\"userLastName\":\"Einstein\"}]"
+            get "/users" `shouldRespondWith` users
+-}

--- a/run-mmlh-reporter.sh
+++ b/run-mmlh-reporter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker run --env-file dist/env-vars.txt -p 8080:8080 -it mmlh-reporter:latest /opt/mmlh-reporter/mmlh-reporter

--- a/run-mmlh-reporter.sh
+++ b/run-mmlh-reporter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo docker run --env-file dist/env-vars.txt -p 8080:8080 -it mmlh-reporter:latest /opt/mmlh-reporter/mmlh-reporter
+sudo docker run --env-file dist/env-vars.txt -p 8080:8080 --dns 8.8.8.8 -it mmlh-reporter:latest /opt/mmlh-reporter/mmlh-reporter

--- a/src/Education/MakeMistakesToLearnHaskell.hs
+++ b/src/Education/MakeMistakesToLearnHaskell.hs
@@ -28,7 +28,6 @@ productionMain = mainFromReportServer "https://mmlh-reporter.herokuapp.com/"
 
 mainFromReportServer :: EndpointUrl -> IO ()
 mainFromReportServer defaultHost = do
-  print defaultHost
   avoidCodingError
   args <- Env.getArgs
   if null args then

--- a/src/Education/MakeMistakesToLearnHaskell/Env.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Env.hs
@@ -7,6 +7,7 @@ module Education.MakeMistakesToLearnHaskell.Env
   , defaultRunHaskellParameters
   , appName
   , homePathEnvVarName
+  , reportServerEnvVarName
   , avoidCodingError
   )
 where
@@ -14,6 +15,7 @@ where
 #include <imports/external.hs>
 #include <imports/io.hs>
 
+import           Education.MakeMistakesToLearnHaskell.Report.Client    (Report, Result(Result), ReportClientError)
 import           Education.MakeMistakesToLearnHaskell.Evaluator.Types
 
 data CommandParameters = CommandParameters
@@ -33,6 +35,7 @@ data Env = Env
   , openWithBrowser :: Text -> IO Bool
   , say :: Text -> IO ()
   , envQcMaxSuccessSize :: Int
+  , postReport :: Report -> IO (Either ReportClientError Result)
   }
 
 defaultEnv :: Env
@@ -47,6 +50,9 @@ defaultEnv = Env
       \url -> Text.putStrLn ("default Env.openWithBrowser: " <> url) >> return True
   , say = Text.putStrLn
   , envQcMaxSuccessSize = 20
+  , postReport = \r -> do
+      putStrLn $ "default postReport: " ++ show r
+      return . Right $ Result "http://example.com/mmlh-reporter-example"
   }
 
 appName :: String
@@ -55,6 +61,10 @@ appName = "mmlh"
 
 homePathEnvVarName :: String
 homePathEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_HOME"
+
+
+reportServerEnvVarName :: String
+reportServerEnvVarName = "MAKE_MISTAKES_TO_LEARN_HASKELL_REPORT_SERVER"
 
 avoidCodingError :: IO ()
 #ifdef mingw32_HOST_OS

--- a/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Exercise/Types.hs
@@ -1,9 +1,16 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
-module Education.MakeMistakesToLearnHaskell.Exercise.Types where
+module Education.MakeMistakesToLearnHaskell.Exercise.Types
+  ( module Education.MakeMistakesToLearnHaskell.Commons.Exercise
+  , Exercise (..)
+  , Result (..)
+  , Record (..)
+  , Diagnosis
+  ) where
 
 #include <imports/external.hs>
 
+import           Education.MakeMistakesToLearnHaskell.Commons.Exercise
 import           Education.MakeMistakesToLearnHaskell.Evaluator.Types
 import           Education.MakeMistakesToLearnHaskell.Env
 
@@ -27,22 +34,8 @@ data Result =
   | NotYetImplemented
   deriving (Eq, Show)
 
-data FailBy =
-    WrongOutput !Details
-  | CommandFailed
-      String   -- ^ Command name
-      !Details -- ^ Output by command
-      !Details -- ^ Diagnosis message
-  deriving (Eq, Show)
-
 newtype Record = Record
   { lastShownName :: Name
   } deriving (Show, Read)
-
-type Details = Text
-
-type SourceCode = Text
-
-type Name = String
 
 type Diagnosis = SourceCode -> Details -> Details

--- a/src/Education/MakeMistakesToLearnHaskell/Report.hs
+++ b/src/Education/MakeMistakesToLearnHaskell/Report.hs
@@ -2,65 +2,28 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Education.MakeMistakesToLearnHaskell.Report
-  ( buildUrl
-  , buildBody
-  , printUrlIfAsked
+  ( printUrlIfAsked
   ) where
 
 #include <imports/external.hs>
 
+import           Education.MakeMistakesToLearnHaskell.Report.Client    (Report (Report),
+                                                                        reportUrl)
+
 import           Education.MakeMistakesToLearnHaskell.Env
 import qualified Education.MakeMistakesToLearnHaskell.Exercise.Types as Exercise
-
-
-buildUrl :: Exercise.Name -> Exercise.SourceCode -> Exercise.FailBy -> Text
-buildUrl name code fb =
-  "https://github.com/haskell-jp/makeMistakesToLearnHaskell-support/issues/new?labels=support&title=Exercise%20"
-    <> Text.fromStrict (Uri.encodeText $ TextS.pack name)
-    <> "&body="
-    <> Text.fromStrict (Uri.encodeText . Text.toStrict $ buildBody code fb)
-
-
-buildBody :: Exercise.SourceCode -> Exercise.FailBy -> Text
-buildBody code fb = Text.strip $ Text.unlines
-  ["# Answer"
-  , ""
-  , "```"
-  , Text.strip code
-  , "```"
-  , ""
-  , case fb of
-        Exercise.WrongOutput out -> Text.unlines
-          [ "# Cause: Wrong Output"
-          , ""
-          , "```"
-          , Text.strip out
-          , "```"
-          ]
-        Exercise.CommandFailed cname cout diag -> Text.unlines
-          [ "# Cause: `" <> Text.pack cname <> "` failed."
-          , ""
-          , "```"
-          , Text.strip cout
-          , "```"
-          , ""
-          , if Text.null diag
-              then "## No Diagnosis"
-              else Text.unlines
-                [ "## Diagnosis"
-                , ""
-                , "```"
-                , Text.strip diag
-                , "```"
-                ]
-          ]
-  ]
 
 
 printUrlIfAsked :: Env -> Exercise.Name -> Exercise.SourceCode -> Exercise.FailBy -> IO ()
 printUrlIfAsked e name code fb = do
   y <- confirm e "Report this failure to ask for a help?"
   when y $ do
-    let url = buildUrl name code fb
-    _ <- openWithBrowser e url
-    say e $ "Open " <> url <> " with your browser!"
+    eurl <- fmap reportUrl <$> postReport e (Report name code fb)
+    case eurl of
+        Right url -> do
+          _ <- openWithBrowser e url
+          say e $ "Open " <> url <> " with your browser!"
+        Left err -> do
+          putStrLn "[WARN] Error when filing an issue at haskell-jp/makeMistakesToLearnHaskell-support."
+          putStrLn "[WARN] This can be a bug. Please report at https://github.com/haskell-jp/makeMistakesToLearnHaskell/issues with the error message below:"
+          print err

--- a/src/imports/io.hs
+++ b/src/imports/io.hs
@@ -1,3 +1,4 @@
 #include <imports/external/io.hs>
 
 import Education.MakeMistakesToLearnHaskell.Text.IO (readUtf8File, writeUtf8FileS)
+import qualified Education.MakeMistakesToLearnHaskell.Report.Client as IO

--- a/src/test/imports/external.hs
+++ b/src/test/imports/external.hs
@@ -1,24 +1,21 @@
 import           Test.Hspec
-import           Test.Hspec.Core.Spec (SpecM)
-import           Test.Main
-                   ( captureProcessResult
-                   , withArgs
-                   , withEnv
-                   , withStdin
-                   , ProcessResult(ProcessResult, prStdout, prStderr, prExitCode, prException)
-                   )
+import           Test.Hspec.Core.Spec             (SpecM)
+import           Test.Main                        (ProcessResult (ProcessResult, prException, prExitCode, prStderr, prStdout),
+                                                   captureProcessResult,
+                                                   withArgs, withEnv, withStdin)
 
 import qualified Paths_makeMistakesToLearnHaskell as Paths
 
-import           Control.Monad (void)
-import           Control.Exception (try)
-import           Data.ByteString.Lazy.Char8 (ByteString)
-import qualified Data.ByteString.Lazy.Char8 as ByteString
-import qualified Data.ByteString.Char8 as ByteString'
-import           Data.Foldable (for_)
-import           Data.Function ((&))
-import qualified Data.Text.Lazy as Text
-import qualified System.Directory as Dir
-import qualified System.Environment as Env
-import           System.Exit (ExitCode(ExitSuccess, ExitFailure))
-import           System.FilePath ((</>))
+import           Control.Concurrent               (forkIO)
+import           Control.Exception                (try)
+import           Control.Monad                    (void)
+import qualified Data.ByteString.Char8            as ByteString'
+import           Data.ByteString.Lazy.Char8       (ByteString)
+import qualified Data.ByteString.Lazy.Char8       as ByteString
+import           Data.Foldable                    (for_)
+import           Data.Function                    ((&))
+import qualified Data.Text.Lazy                   as Text
+import qualified System.Directory                 as Dir
+import qualified System.Environment               as Env
+import           System.Exit                      (ExitCode (ExitFailure, ExitSuccess))
+import           System.FilePath                  ((</>))

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-13.20
+resolver: lts-13.24
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -37,10 +37,13 @@ resolver: lts-13.20
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
+- reporter/
+- commons/
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  []
+  - 'ulid-0.2.0.0@sha256:ac415298b0272479909ca576f4444862ae942ed85c7849fa0675e3bf496be6f3'
+  - 'crockford-0.2@sha256:6ec593711a20bd4b81a0fc13f3d850d2d890690941d777230fbf980c483e434a'
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Education/MakeMistakesToLearnHaskellSpec.hs
+++ b/test/Education/MakeMistakesToLearnHaskellSpec.hs
@@ -4,6 +4,8 @@ module Education.MakeMistakesToLearnHaskellSpec (main, spec) where
 
 #include <test/imports/external.hs>
 
+import           Education.MakeMistakesToLearnHaskell.Report.Server (startStub)
+
 import qualified Education.MakeMistakesToLearnHaskell
 import           Education.MakeMistakesToLearnHaskell.Env
 
@@ -11,7 +13,9 @@ import           Education.MakeMistakesToLearnHaskell.Env
 -- `main` is here so that this module can be run from GHCi on its own.  It is
 -- not needed for automatic spec discovery.
 main :: IO ()
-main = hspec spec
+main = do
+  _ <- forkIO $ startStub 191821
+  hspec spec
 
 
 spec :: Spec
@@ -81,9 +85,10 @@ runMmlh args stdinDat = do
   Dir.createDirectoryIfMissing False "./tmp/"
   let env = [(homePathEnvVarName, Just "./tmp/")]
   withArgs args
-    $ withStdin stdinDat
-    $ withEnv env
-    $ captureProcessResult Education.MakeMistakesToLearnHaskell.main
+    . withStdin stdinDat
+    . withEnv env
+    . captureProcessResult
+    $ Education.MakeMistakesToLearnHaskell.mainFromReportServer "http://127.0.0.1:191821"
 
 
 includes :: ByteString'.ByteString -> ByteString'.ByteString -> Bool


### PR DESCRIPTION
Fix #101 

- Add a new server to accept report the users' failures by committing to https://github.com/haskell-jp-bot/makeMistakesToLearnHaskell-support/
    - By making a commit with the user's answer and the error message by mmlh, to a new branch of https://github.com/haskell-jp-bot/makeMistakesToLearnHaskell-support/, [#mmlh-support channel on our Slack Workspace](https://haskell-jp.slack.com/messages/CJYCNBXDY/) gets notified.
    - Then I'll make a comment on the commit.
        - GitHub's commit pages can **have comments for every line of the committed codes** (which solves the very problem of https://github.com/haskell-jp/makeMistakesToLearnHaskell/issues/101).
    - Deployed on Heroku so far.
- Create new packages:
    - mmlh-reporter: The new server app and client library to submit a report by the users.
    - mmlh-commons: Things common to mmlh-reporter and makeMistakesToLearnHaskell.